### PR TITLE
Updated xmltojson.xml to fix the deployment issue

### DIFF
--- a/sample-proxies/xmltojson/apiproxy/policies/xmltojson.xml
+++ b/sample-proxies/xmltojson/apiproxy/policies/xmltojson.xml
@@ -1,2 +1,3 @@
 <XMLToJSON name="xmltojson">
+<Options></Options>
 </XMLToJSON>


### PR DESCRIPTION
Updated the policy xmltojson.xml to fix the deployment issue. Here is the error description:
Import failed to /v1/organizations/arch123/apis?action=import&name=xmltojson with status 400:
{
  "code" : "steps.xml2json.EitherOptionOrFormat",
  "message" : "XMLToJSON[{0}]: Either Options or Format must be specified",
  "contexts" : [ ]
}