### PR TITLE
Correct XSD path errors

### DIFF
--- a/schemas/configuration/all.xsd
+++ b/schemas/configuration/all.xsd
@@ -9,7 +9,9 @@
     <xs:include schemaLocation="entities.xsd"/>
     <xs:include schemaLocation="proxy_endpoint.xsd"/>
     <xs:include schemaLocation="target_endpoint.xsd"/>
-    <xs:include schemaLocation="steps/all.xsd"/>
+    
+    <!-- This does not appear to exist -->
+    <!--<xs:include schemaLocation="steps/all.xsd"/>-->
 
     <xs:simpleType name="deployAction">
         <xs:restriction base="xs:string">

--- a/schemas/policy/cache.xsd
+++ b/schemas/policy/cache.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../properties.xsd"/>
+    <xs:include schemaLocation="../configuration/properties.xsd"/>
 
     <xs:element name="LookupCache">
         <xs:complexType>

--- a/schemas/policy/keyvaluemap-operations.xsd
+++ b/schemas/policy/keyvaluemap-operations.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../properties.xsd"/>
+    <xs:include schemaLocation="../configuration/properties.xsd"/>
 
     <xs:element name="KeyValueMapOperations">
         <xs:complexType>

--- a/schemas/policy/message_logging.xsd
+++ b/schemas/policy/message_logging.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../destinations.xsd"/>
+    <xs:include schemaLocation="../configuration/destinations.xsd"/>
 
     <xs:element name="MessageLogging">
         <xs:complexType>

--- a/schemas/policy/ratelimit.xsd
+++ b/schemas/policy/ratelimit.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../destinations.xsd"/>
+    <xs:include schemaLocation="../configuration/destinations.xsd"/>
 
     <xs:element name="Quota">
         <xs:complexType>

--- a/schemas/policy/service_callout.xsd
+++ b/schemas/policy/service_callout.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../target_endpoint.xsd"/>
+    <xs:include schemaLocation="../configuration/target_endpoint.xsd"/>
 
     <xs:element name="ServiceCallout">
         <xs:complexType>


### PR DESCRIPTION
The provided schemas did not have proper paths within them which lead to validation issues. I corrected them as best I could, but having valid, self-consistent schemas would be very helpful for building applications outside of the web ui.

Also, would love to see non-colliding namespaces used within the schemas
