### PR TITLE
Add schema namespaces

### DIFF
--- a/schemas/configuration/all.xsd
+++ b/schemas/configuration/all.xsd
@@ -9,7 +9,9 @@
     <xs:include schemaLocation="entities.xsd"/>
     <xs:include schemaLocation="proxy_endpoint.xsd"/>
     <xs:include schemaLocation="target_endpoint.xsd"/>
-    <xs:include schemaLocation="steps/all.xsd"/>
+    
+    <!-- This does not appear to exist -->
+    <!--<xs:include schemaLocation="steps/all.xsd"/>-->
 
     <xs:simpleType name="deployAction">
         <xs:restriction base="xs:string">

--- a/schemas/configuration/destinations.xsd
+++ b/schemas/configuration/destinations.xsd
@@ -4,79 +4,72 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:complexType name="intervalType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="unit">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="second"/>
-                            <xs:enumeration value="minute"/>
-                            <xs:enumeration value="hour"/>
-                            <xs:enumeration value="day"/>
-                            <xs:enumeration value="month"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:attribute>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-
+<xs:schema xmlns="http://www.apigee.com/configuration/destinations" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/configuration/destinations">
+	<xs:complexType name="intervalType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="unit">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="second"/>
+							<xs:enumeration value="minute"/>
+							<xs:enumeration value="hour"/>
+							<xs:enumeration value="day"/>
+							<xs:enumeration value="month"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 	<xs:complexType name="destinationType">
-        <xs:sequence/>
+		<xs:sequence/>
 		<xs:attribute name="async" type="xs:boolean" use="optional" default="true"/>
 	</xs:complexType>
-
-    <xs:element name="Destination" type="destinationType" abstract="true"/>
-
-    <xs:element name="File" substitutionGroup="Destination">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="destinationType">
-                    <xs:sequence>
-                        <xs:element name="Message" type="xs:string"/>
-                        <xs:element name="FileName" type="xs:string"/>
-                        <xs:element name="FileRotationOptions" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="FileRotationType" default="SIZE">
-                                        <xs:simpleType>
-                                            <xs:restriction base="xs:string">
-                                                <xs:enumeration value="TIME"/>
-                                                <xs:enumeration value="SIZE"/>
-                                                <xs:enumeration value="TIME_SIZE"/>
-                                            </xs:restriction>
-                                        </xs:simpleType>
-                                    </xs:element>
-                                    <xs:element name="MaxFileSizeInMB" type="xs:int" minOccurs="0" default="128"/>
-                                    <xs:element name="RotationFrequency" type="intervalType" minOccurs="0" default="1"/>
-                                    <xs:element name="MaxFilesToRetain" type="xs:int" minOccurs="0" default="8"/>
-                                </xs:sequence>
-                                <xs:attribute name="rotateFileOnStartup" type="xs:boolean" use="optional" default="true"/>
-                            </xs:complexType>
-                        </xs:element>
-
-                    </xs:sequence>
-                    <xs:attribute name="rotateLogFileOnStartup" type="xs:boolean" default="true"/>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Syslog" substitutionGroup="Destination">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="destinationType">
-                    <xs:sequence>
-                        <xs:element name="Message" type="xs:string"/>
-                        <xs:element name="Host" type="xs:string" minOccurs="0" default="localhost"/>
-                        <xs:element name="Port" type="xs:int" minOccurs="0" default="514"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+	<xs:element name="Destination" type="destinationType" abstract="true"/>
+	<xs:element name="File" substitutionGroup="Destination">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="destinationType">
+					<xs:sequence>
+						<xs:element name="Message" type="xs:string"/>
+						<xs:element name="FileName" type="xs:string"/>
+						<xs:element name="FileRotationOptions" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="FileRotationType" default="SIZE">
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:enumeration value="TIME"/>
+												<xs:enumeration value="SIZE"/>
+												<xs:enumeration value="TIME_SIZE"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="MaxFileSizeInMB" type="xs:int" default="128" minOccurs="0"/>
+									<xs:element name="RotationFrequency" type="intervalType" default="1" minOccurs="0"/>
+									<xs:element name="MaxFilesToRetain" type="xs:int" default="8" minOccurs="0"/>
+								</xs:sequence>
+								<xs:attribute name="rotateFileOnStartup" type="xs:boolean" use="optional" default="true"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="rotateLogFileOnStartup" type="xs:boolean" default="true"/>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Syslog" substitutionGroup="Destination">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="destinationType">
+					<xs:sequence>
+						<xs:element name="Message" type="xs:string"/>
+						<xs:element name="Host" type="xs:string" default="localhost" minOccurs="0"/>
+						<xs:element name="Port" type="xs:int" default="514" minOccurs="0"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/configuration/endpoint.xsd
+++ b/schemas/configuration/endpoint.xsd
@@ -1,94 +1,87 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:complexType name="endpointType">
-        <xs:sequence>
-            <xs:element name="Description" type="xs:string" minOccurs="0"/>
-            <xs:element name="Statistics" minOccurs="0">
-                <xs:complexType>
-                    <xs:choice>
-                        <xs:element name="EnableAll" type="xs:boolean"/>
-                        <xs:element name="Statistic" type="xs:string" maxOccurs="unbounded"/>
-                    </xs:choice>
-                </xs:complexType>
-            </xs:element>
-
-            <xs:element name="PreFlow" type="flowType" minOccurs="0"/>
-            <xs:element name="PostFlow" type="flowType" minOccurs="0"/>
-            <xs:element name="Flows" minOccurs="0">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="Flow" type="conditionalFlowType" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-
-            <xs:element ref="FaultRules" minOccurs="0"/>
-        </xs:sequence>
-        <xs:attribute name="name" type="xs:NCName" use="required"/>
-    </xs:complexType>
-
-    <xs:element name="FaultRules">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="FaultRule" minOccurs="0" maxOccurs="unbounded">
-                    <xs:complexType>
-                        <xs:complexContent>
-                            <xs:extension base="stepsType">
-                                <xs:sequence>
-                                    <xs:element name="Description" type="xs:string" minOccurs="0"/>
-                                    <xs:element name="Condition" type="xs:string" minOccurs="0"/>
-                                </xs:sequence>
-                            </xs:extension>
-                        </xs:complexContent>
-                    </xs:complexType>
-                </xs:element>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="stepsType">
-        <xs:sequence>
-            <xs:element name="Step" minOccurs="0" maxOccurs="unbounded">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="Name" type="xs:NCName"/>
-                        <xs:element name="Condition" type="xs:string" minOccurs="0"/>
-                        <xs:element ref="FaultRules" minOccurs="0"/>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="flowType">
-        <xs:sequence>
-            <xs:element name="Description" type="xs:string" minOccurs="0"/>
-            <xs:element name="Request" type="stepsType" minOccurs="0"/>
-            <xs:element name="Response" type="stepsType" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="conditionalFlowType">
-        <xs:complexContent>
-            <xs:extension base="flowType">
-                <xs:sequence>
-                    <xs:element name="Condition" type="xs:string" minOccurs="0"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:element name="Flows">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Flow" type="flowType" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-</xs:schema>    
+<xs:schema xmlns="http://www.apigee.com/configuration/endpoint" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/configuration/endpoint">
+	<xs:complexType name="endpointType">
+		<xs:sequence>
+			<xs:element name="Description" type="xs:string" minOccurs="0"/>
+			<xs:element name="Statistics" minOccurs="0">
+				<xs:complexType>
+					<xs:choice>
+						<xs:element name="EnableAll" type="xs:boolean"/>
+						<xs:element name="Statistic" type="xs:string" maxOccurs="unbounded"/>
+					</xs:choice>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="PreFlow" type="flowType" minOccurs="0"/>
+			<xs:element name="PostFlow" type="flowType" minOccurs="0"/>
+			<xs:element name="Flows" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Flow" type="conditionalFlowType" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="FaultRules" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="name" type="xs:NCName" use="required"/>
+	</xs:complexType>
+	<xs:element name="FaultRules">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="FaultRule" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="stepsType">
+								<xs:sequence>
+									<xs:element name="Description" type="xs:string" minOccurs="0"/>
+									<xs:element name="Condition" type="xs:string" minOccurs="0"/>
+								</xs:sequence>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="stepsType">
+		<xs:sequence>
+			<xs:element name="Step" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="Name" type="xs:NCName"/>
+						<xs:element name="Condition" type="xs:string" minOccurs="0"/>
+						<xs:element ref="FaultRules" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="flowType">
+		<xs:sequence>
+			<xs:element name="Description" type="xs:string" minOccurs="0"/>
+			<xs:element name="Request" type="stepsType" minOccurs="0"/>
+			<xs:element name="Response" type="stepsType" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="conditionalFlowType">
+		<xs:complexContent>
+			<xs:extension base="flowType">
+				<xs:sequence>
+					<xs:element name="Condition" type="xs:string" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:element name="Flows">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Flow" type="flowType" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/schemas/configuration/entities.xsd
+++ b/schemas/configuration/entities.xsd
@@ -1,131 +1,120 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="sslinfo.xsd"/>
-
-    <xs:element name="Organization">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Description" type="xs:string" minOccurs="0"/>
-                <xs:element name="DisplayName" type="xs:string"/>
-                <xs:element name="AutoGenerateForAppKey" type="xs:boolean" minOccurs="0" default="false"/>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-            <xs:attribute name="type" type="OrgTypeValue"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Environment">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Description" type="xs:string" minOccurs="0"/>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="APIProxy">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Description" type="xs:string" minOccurs="0"/>
-                <xs:element name="ConfigurationVersion">
-                    <xs:complexType>
-                        <xs:sequence/>
-                        <xs:attribute name="majorVersion" type="xs:int" fixed="4"/>
-                        <xs:attribute name="minorVersion" type="xs:int" fixed="0"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="VirtualHost">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Description" type="xs:string" minOccurs="0"/>
-                <xs:element name="Interfaces" minOccurs="0">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="Interface" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="HostAliases" minOccurs="0">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="HostAlias" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element ref="Port"/>
-                <xs:element name="IOTimeoutInMilliSeconds" type="xs:long" minOccurs="0"/>
-                <xs:element name="MaximumKeepAliveClientCount" type="xs:int" minOccurs="0"/>
-                <xs:element ref="SSLInfo" minOccurs="0"/>
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="KeyStore">
-        <xs:complexType>
-            <xs:sequence/>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="CRLStore">
-        <xs:complexType>
-            <xs:sequence/>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="TargetServer">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Description" type="xs:string" minOccurs="0"/>
-                <xs:element name="IsEnabled" type="xs:boolean" minOccurs="0" default="true"/>
-                <xs:element name="Host" type="xs:string" minOccurs="1"/>
-                <xs:element ref="Port"/>
-                <xs:element ref="SSLInfo" minOccurs="0"/>
-
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Port">
-        <xs:simpleType>
-            <xs:restriction base="xs:int">
-                <xs:minInclusive value="1"/>
-                <xs:maxInclusive value="65535"/>
-            </xs:restriction>
-        </xs:simpleType>
-    </xs:element>
-
-    <xs:simpleType name="OrgTypeValue">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="trial"/>
-            <xs:enumeration value="paid"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+<xs:schema xmlns="http://www.apigee.com/configuration/entities" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ssl="http://www.apigee.com/configuration/sslinfo" targetNamespace="http://www.apigee.com/configuration/entities">
+	<xs:import namespace="http://www.apigee.com/configuration/sslinfo" schemaLocation="sslinfo.xsd"/>
+	<xs:element name="Organization">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Description" type="xs:string" minOccurs="0"/>
+				<xs:element name="DisplayName" type="xs:string"/>
+				<xs:element name="AutoGenerateForAppKey" type="xs:boolean" default="false" minOccurs="0"/>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+			<xs:attribute name="type" type="OrgTypeValue"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Environment">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Description" type="xs:string" minOccurs="0"/>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="APIProxy">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Description" type="xs:string" minOccurs="0"/>
+				<xs:element name="ConfigurationVersion">
+					<xs:complexType>
+						<xs:sequence/>
+						<xs:attribute name="majorVersion" type="xs:int" fixed="4"/>
+						<xs:attribute name="minorVersion" type="xs:int" fixed="0"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="VirtualHost">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Description" type="xs:string" minOccurs="0"/>
+				<xs:element name="Interfaces" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Interface" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="HostAliases" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="HostAlias" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element ref="Port"/>
+				<xs:element name="IOTimeoutInMilliSeconds" type="xs:long" minOccurs="0"/>
+				<xs:element name="MaximumKeepAliveClientCount" type="xs:int" minOccurs="0"/>
+				<xs:element ref="ssl:SSLInfo" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="KeyStore">
+		<xs:complexType>
+			<xs:sequence/>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="CRLStore">
+		<xs:complexType>
+			<xs:sequence/>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="TargetServer">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Description" type="xs:string" minOccurs="0"/>
+				<xs:element name="IsEnabled" type="xs:boolean" default="true" minOccurs="0"/>
+				<xs:element name="Host" type="xs:string" minOccurs="1"/>
+				<xs:element ref="Port"/>
+				<xs:element ref="ssl:SSLInfo" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Port">
+		<xs:simpleType>
+			<xs:restriction base="xs:int">
+				<xs:minInclusive value="1"/>
+				<xs:maxInclusive value="65535"/>
+			</xs:restriction>
+		</xs:simpleType>
+	</xs:element>
+	<xs:simpleType name="OrgTypeValue">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="trial"/>
+			<xs:enumeration value="paid"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/configuration/properties.xsd
+++ b/schemas/configuration/properties.xsd
@@ -1,32 +1,31 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:element name="Properties">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Property" minOccurs="0" maxOccurs="unbounded">
-                    <xs:complexType>
-                        <xs:simpleContent>
-                            <xs:extension base="xs:string">
-                                <xs:attribute name="name" type="xs:string" use="required"/>
-                            </xs:extension>
-                        </xs:simpleContent>
-                    </xs:complexType>
-                </xs:element>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="propertyType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="ref" type="xs:string" use="optional"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-</xs:schema>    
+<xs:schema xmlns="http://www.apigee.com/configuration/properties" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/configuration/properties">
+	<xs:element name="Properties">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Property" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:simpleContent>
+							<xs:extension base="xs:string">
+								<xs:attribute name="name" type="xs:string" use="required"/>
+							</xs:extension>
+						</xs:simpleContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="propertyType">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="ref" type="xs:string" use="optional"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+</xs:schema>

--- a/schemas/configuration/proxy_endpoint.xsd
+++ b/schemas/configuration/proxy_endpoint.xsd
@@ -1,49 +1,47 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="endpoint.xsd"/>
-    <xs:include schemaLocation="properties.xsd"/>
-    <xs:include schemaLocation="target_endpoint.xsd"/>
-
-    <xs:element name="ProxyEndpoint">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="endpointType">
-                    <xs:sequence>
-                        <xs:element name="HTTPProxyConnection">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="BasePath" type="xs:string"/>
-                                    <xs:element name="VirtualHost" type="xs:string" minOccurs="0"/>
-                                    <xs:element ref="Properties" minOccurs="0"/>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element ref="RouteRule" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="RouteRule">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Condition" type="xs:string" minOccurs="0"/>
-                <xs:choice>
-                    <xs:element name="TargetEndpoint" type="xs:NCName"/>
-                    <xs:sequence>
-                        <xs:element name="URL"/>
-                        <xs:element ref="HTTPTargetConnection"/>
-                    </xs:sequence>
-                </xs:choice>
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:NCName" use="required"/>
-        </xs:complexType>
-    </xs:element>
-</xs:schema>    
+<xs:schema xmlns="http://www.apigee.com/policy/target_endpoint" xmlns:endpoint="http://www.apigee.com/configuration/endpoint" xmlns:target_endpoint="http://www.apigee.com/configuration/target_endpoint" xmlns:prop="http://www.apigee.com/configuration/properties" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/target_endpoint">
+	<xs:import namespace="http://www.apigee.com/configuration/endpoint" schemaLocation="endpoint.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/properties" schemaLocation="../configuration/properties.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/target_endpoint" schemaLocation="target_endpoint.xsd"/>
+	<xs:element name="ProxyEndpoint">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="endpoint:endpointType">
+					<xs:sequence>
+						<xs:element name="HTTPProxyConnection">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="BasePath" type="xs:string"/>
+									<xs:element name="VirtualHost" type="xs:string" minOccurs="0"/>
+									<xs:element ref="prop:Properties" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element ref="RouteRule" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="RouteRule">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Condition" type="xs:string" minOccurs="0"/>
+				<xs:choice>
+					<xs:element name="TargetEndpoint" type="xs:NCName"/>
+					<xs:sequence>
+						<xs:element name="URL"/>
+						<xs:element ref="target_endpoint:HTTPTargetConnection"/>
+					</xs:sequence>
+				</xs:choice>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:NCName" use="required"/>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/schemas/configuration/sslinfo.xsd
+++ b/schemas/configuration/sslinfo.xsd
@@ -1,38 +1,38 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:element name="SSLInfo">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Enabled" type="xs:boolean" minOccurs="0" default="false"/>
-                <xs:element name="ClientAuthEnabled" type="xs:boolean" minOccurs="0" default="false"/>
-                <xs:element name="KeyStore" type="xs:string" minOccurs="0"/>
-                <xs:element name="KeyAlias" type="xs:string" minOccurs="0"/>
-                <xs:element name="CommonName" type="xs:string" minOccurs="0"/>
-                <xs:element name="Protocols" minOccurs="0">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="Protocol" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Ciphers" minOccurs="0">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="Cipher" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="TrustStore" type="xs:string" minOccurs="0"/>
-                <xs:element name="IgnoreValidationErrors" type="xs:boolean" minOccurs="0" default="false"/>
-                <xs:element name="CRLStore" type="xs:string" minOccurs="0"/>
-            </xs:sequence>
-            <xs:attribute name="name" type="xs:string" use="required"/>
-        </xs:complexType>
-    </xs:element>
+<xs:schema xmlns="http://www.apigee.com/configuration/sslinfo" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/configuration/sslinfo">
+	<xs:element name="SSLInfo">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Enabled" type="xs:boolean" default="false" minOccurs="0"/>
+				<xs:element name="ClientAuthEnabled" type="xs:boolean" default="false" minOccurs="0"/>
+				<xs:element name="KeyStore" type="xs:string" minOccurs="0"/>
+				<xs:element name="KeyAlias" type="xs:string" minOccurs="0"/>
+				<xs:element name="CommonName" type="xs:string" minOccurs="0"/>
+				<xs:element name="Protocols" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Protocol" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Ciphers" minOccurs="0">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Cipher" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="TrustStore" type="xs:string" minOccurs="0"/>
+				<xs:element name="IgnoreValidationErrors" type="xs:boolean" default="false" minOccurs="0"/>
+				<xs:element name="CRLStore" type="xs:string" minOccurs="0"/>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:string" use="required"/>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/configuration/target_endpoint.xsd
+++ b/schemas/configuration/target_endpoint.xsd
@@ -1,145 +1,138 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="endpoint.xsd"/>
-    <xs:include schemaLocation="sslinfo.xsd"/>
-    <xs:include schemaLocation="properties.xsd"/>
-
-    <xs:element name="TargetEndpoint">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="endpointType">
-                    <xs:sequence>
-                        <xs:element ref="HTTPTargetConnection"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="HTTPTargetConnection">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:choice>
-                    <xs:sequence>
-                        <xs:element name="URL" type="xs:string" minOccurs="1"/>
-                        <xs:element ref="SSLInfo" minOccurs="0"/>
-                    </xs:sequence>
-                    <xs:sequence>
-                        <xs:element name="Path" type="xs:string"/>
-                        <xs:element name="ErrorResponse" type="responseType" minOccurs="0"/>
-                        <xs:element ref="HealthMonitor" minOccurs="0"/>
-                        <xs:element ref="SessionCache" minOccurs="0"/>
-                        <xs:element ref="LoadBalancer" minOccurs="0"/>
-                    </xs:sequence>
-                </xs:choice>
-                <xs:element ref="Properties" minOccurs="0"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Header">
-        <xs:complexType>
-            <xs:simpleContent>
-                <xs:extension base="xs:string">
-                    <xs:attribute name="name" use="required"/>
-                </xs:extension>
-            </xs:simpleContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="responseType">
-        <xs:sequence>
-            <xs:element ref="Header" minOccurs="0" maxOccurs="unbounded"/>
-            <xs:element name="ResponseCode" type="xs:positiveInteger" maxOccurs="unbounded"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:element name="HealthMonitor">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="IsEnabled" minOccurs="0" type="xs:boolean" default="false"/>
-                <xs:element name="IntervalInSec" type="xs:int"/>
-                <xs:choice>
-                    <xs:element name="HTTPMonitor">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Request">
-                                    <xs:complexType>
-                                        <xs:sequence>
-                                            <xs:element name="Port" type="xs:int"/>
-                                            <xs:element name="ConnectTimeoutInSec" type="xs:int" minOccurs="0" default="30000"/>
-                                            <xs:element name="SocketReadTimeoutInSec" type="xs:int"/>
-                                            <xs:element name="Verb" type="xs:string" minOccurs="0" default="GET"/>
-                                            <xs:element name="Path" type="xs:string" minOccurs="0" default="/"/>
-                                            <xs:element ref="Header" minOccurs="0" maxOccurs="unbounded"/>
-                                            <xs:element name="Payload" type="xs:string"/>
-                                        </xs:sequence>
-                                    </xs:complexType>
-                                </xs:element>
-                                <xs:element name="Response" type="responseType"/>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="TCPMonitor">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Port" type="xs:int"/>
-                                <xs:element name="ConnectTimeoutInSec" type="xs:int"/>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:choice>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="LoadBalancer">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Algorithm" minOccurs="1">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="RoundRobin"/>
-                            <xs:enumeration value="Weighted"/>
-                            <xs:enumeration value="LeastConnections"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="MaxFailures" type="xs:int" minOccurs="0" default="0"/>
-                <xs:element name="RetryEnabled" type="xs:boolean" minOccurs="0" default="true"/>
-                <xs:element name="Server" minOccurs="1" maxOccurs="unbounded">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="IsEnabled" minOccurs="0" type="xs:boolean" default="true"/>
-                            <xs:element name="IsFallback" minOccurs="0" type="xs:boolean" default="false"/>
-                            <xs:element name="Weight" minOccurs="0" type="xs:positiveInteger" default="1"/>
-                        </xs:sequence>
-                        <xs:attribute name="name" type="xs:string" use="required"/>
-                    </xs:complexType>
-                </xs:element>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="SessionCache">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="SessionKey" type="xs:string" minOccurs="1"/>
-                <xs:element name="KeyType" minOccurs="0" default="Cookie">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="Cookie"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="SessionTimeoutInSec" type="propertyType" minOccurs="0" default="-1"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-</xs:schema>    
+<xs:schema xmlns="http://www.apigee.com/configuration/target_endpoint" xmlns:endpoint="http://www.apigee.com/configuration/endpoint" xmlns:ssl="http://www.apigee.com/configuration/sslinfo" xmlns:prop="http://www.apigee.com/configuration/properties" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/configuration/target_endpoint">
+	<xs:import namespace="http://www.apigee.com/configuration/endpoint" schemaLocation="endpoint.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/sslinfo" schemaLocation="sslinfo.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/properties" schemaLocation="../configuration/properties.xsd"/>
+	<xs:element name="TargetEndpoint">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="endpoint:endpointType">
+					<xs:sequence>
+						<xs:element ref="HTTPTargetConnection"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="HTTPTargetConnection">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:choice>
+					<xs:sequence>
+						<xs:element name="URL" type="xs:string" minOccurs="1"/>
+						<xs:element ref="ssl:SSLInfo" minOccurs="0"/>
+					</xs:sequence>
+					<xs:sequence>
+						<xs:element name="Path" type="xs:string"/>
+						<xs:element name="ErrorResponse" type="responseType" minOccurs="0"/>
+						<xs:element ref="HealthMonitor" minOccurs="0"/>
+						<xs:element ref="SessionCache" minOccurs="0"/>
+						<xs:element ref="LoadBalancer" minOccurs="0"/>
+					</xs:sequence>
+				</xs:choice>
+				<xs:element ref="prop:Properties" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Header">
+		<xs:complexType>
+			<xs:simpleContent>
+				<xs:extension base="xs:string">
+					<xs:attribute name="name" use="required"/>
+				</xs:extension>
+			</xs:simpleContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="responseType">
+		<xs:sequence>
+			<xs:element ref="Header" minOccurs="0" maxOccurs="unbounded"/>
+			<xs:element name="ResponseCode" type="xs:positiveInteger" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="HealthMonitor">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="IsEnabled" type="xs:boolean" default="false" minOccurs="0"/>
+				<xs:element name="IntervalInSec" type="xs:int"/>
+				<xs:choice>
+					<xs:element name="HTTPMonitor">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Request">
+									<xs:complexType>
+										<xs:sequence>
+											<xs:element name="Port" type="xs:int"/>
+											<xs:element name="ConnectTimeoutInSec" type="xs:int" default="30000" minOccurs="0"/>
+											<xs:element name="SocketReadTimeoutInSec" type="xs:int"/>
+											<xs:element name="Verb" type="xs:string" default="GET" minOccurs="0"/>
+											<xs:element name="Path" type="xs:string" default="/" minOccurs="0"/>
+											<xs:element ref="Header" minOccurs="0" maxOccurs="unbounded"/>
+											<xs:element name="Payload" type="xs:string"/>
+										</xs:sequence>
+									</xs:complexType>
+								</xs:element>
+								<xs:element name="Response" type="responseType"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="TCPMonitor">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Port" type="xs:int"/>
+								<xs:element name="ConnectTimeoutInSec" type="xs:int"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+				</xs:choice>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="LoadBalancer">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Algorithm" minOccurs="1">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="RoundRobin"/>
+							<xs:enumeration value="Weighted"/>
+							<xs:enumeration value="LeastConnections"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="MaxFailures" type="xs:int" default="0" minOccurs="0"/>
+				<xs:element name="RetryEnabled" type="xs:boolean" default="true" minOccurs="0"/>
+				<xs:element name="Server" minOccurs="1" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="IsEnabled" type="xs:boolean" default="true" minOccurs="0"/>
+							<xs:element name="IsFallback" type="xs:boolean" default="false" minOccurs="0"/>
+							<xs:element name="Weight" type="xs:positiveInteger" default="1" minOccurs="0"/>
+						</xs:sequence>
+						<xs:attribute name="name" type="xs:string" use="required"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SessionCache">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="SessionKey" type="xs:string" minOccurs="1"/>
+				<xs:element name="KeyType" default="Cookie" minOccurs="0">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="Cookie"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="SessionTimeoutInSec" type="prop:propertyType" default="-1" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/schemas/oauth/apiproducts.xsd
+++ b/schemas/oauth/apiproducts.xsd
@@ -4,83 +4,81 @@ Apigee(TM) and the Apigee logo are trademarks or
 registered trademarks of Apigee Corp. or its subsidiaries.  All other
 trademarks are the property of their respective owners.
  -->
-
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified"
-           xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:element name="ApiProduct">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element type="xs:string" name="Description"/>
-                <xs:element type="xs:string" name="DisplayName"/>
-                <xs:element name="ApprovalType">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="auto"/>
-                            <xs:enumeration value="manual"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="ApiResources">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element type="xs:string" name="ApiResource" maxOccurs="unbounded" minOccurs="0"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Scopes">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element type="xs:string" name="Scope" maxOccurs="unbounded" minOccurs="0"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Environments">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element type="xs:string" name="Environment" maxOccurs="unbounded" minOccurs="0"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Proxies">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element type="xs:string" name="Proxy" maxOccurs="unbounded" minOccurs="0"/>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element type="xs:long" name="CreatedAt"/>
-                <xs:element type="xs:string" name="CreatedBy"/>
-                <xs:element type="xs:long" name="LastModifiedAt"/>
-                <xs:element type="xs:string" name="LastModifiedBy"/>
-                <xs:element type="xs:long" name="Quota" maxOccurs="1" minOccurs="0"/>
-                <xs:element type="xs:long" name="QuotaInterval" maxOccurs="1" minOccurs="0"/>
-                <xs:element name="QuotaTimeUnit" maxOccurs="1" minOccurs="0">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="second"/>
-                            <xs:enumeration value="minute"/>
-                            <xs:enumeration value="hour"/>
-                            <xs:enumeration value="day"/>
-                            <xs:enumeration value="month"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="Attributes">
-                    <xs:complexType>
-                        <xs:sequence>
-                            <xs:element name="Attribute" maxOccurs="unbounded" minOccurs="0">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element type="xs:string" name="Name"/>
-                                        <xs:element type="xs:string" name="Value"/>
-                                    </xs:sequence>
-                                </xs:complexType>
-                            </xs:element>
-                        </xs:sequence>
-                    </xs:complexType>
-                </xs:element>
-            </xs:sequence>
-            <xs:attribute type="xs:string" name="name"/>
-        </xs:complexType>
-    </xs:element>
+<xs:schema targetNamespace="http://www.apigee.com/oauth/api_product" xmlns="http://www.apigee.com/oauth/api_product" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:element name="ApiProduct">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Description" type="xs:string"/>
+				<xs:element name="DisplayName" type="xs:string"/>
+				<xs:element name="ApprovalType">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="auto"/>
+							<xs:enumeration value="manual"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="ApiResources">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="ApiResource" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Scopes">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Scope" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Environments">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Environment" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Proxies">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Proxy" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+				<xs:element name="Quota" type="xs:long" minOccurs="0" maxOccurs="1"/>
+				<xs:element name="QuotaInterval" type="xs:long" minOccurs="0" maxOccurs="1"/>
+				<xs:element name="QuotaTimeUnit" minOccurs="0" maxOccurs="1">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="second"/>
+							<xs:enumeration value="minute"/>
+							<xs:enumeration value="hour"/>
+							<xs:enumeration value="day"/>
+							<xs:enumeration value="month"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="Attributes">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="Attribute" minOccurs="0" maxOccurs="unbounded">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="Name" type="xs:string"/>
+										<xs:element name="Value" type="xs:string"/>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:string"/>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/oauth/common_definitions.xsd
+++ b/schemas/oauth/common_definitions.xsd
@@ -1,35 +1,31 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-
-    <xs:element name="Attributes">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element maxOccurs="unbounded" ref="Attribute" minOccurs="0"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Attribute">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Name" type="xs:string"/>
-                <xs:element name="Value" type="xs:string"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Count">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="value" type="xs:string" maxOccurs="1" minOccurs="0"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/oauth/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/oauth/common" elementFormDefault="qualified">
+	<xs:element name="Attributes">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Attribute" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Attribute">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Name" type="xs:string"/>
+				<xs:element name="Value" type="xs:string"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Count">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="1"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/oauth/developer_apps.xsd
+++ b/schemas/oauth/developer_apps.xsd
@@ -4,96 +4,84 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-    <xs:include schemaLocation="common_definitions.xsd"/>
-
-    <xs:element name="Apps">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="App" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="App">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="AccessType" type="xs:string"/>
-                <xs:element name="CallbackUrl" type="xs:string"/>
-                <xs:element ref="ApiProducts" minOccurs="0"/>
-                <xs:element ref="Credentials" minOccurs="0"/>
-                <xs:element ref="Attributes" minOccurs="0"/>
-                <xs:element name="developerEmail" minOccurs="0" type="xs:string"/>
-                <xs:element name="Status" minOccurs="0" type="statusType"/>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:all>
-            <xs:attribute name="name" use="required" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Credentials">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="Credential" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Credential">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="ConsumerKey" type="xs:string"/>
-                <xs:element name="ConsumerSecret" type="xs:string"/>
-                <xs:element ref="ApiProducts"/>
-                <xs:element name="Status" minOccurs="0" type="statusType"/>
-                <xs:element ref="Attributes" minOccurs="0"/>
-            </xs:all>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="CredentialRequest">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="ConsumerKey" type="xs:string"/>
-                <xs:element name="Status" minOccurs="0" type="statusType"/>
-                <xs:element ref="Attributes" minOccurs="0"/>
-                <xs:element name="ApiProducts" minOccurs="0" type="ApiProductNamesType"/>
-            </xs:all>
-        </xs:complexType>
-    </xs:element>
-
-
-    <xs:element name="ApiProducts">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="ApiProduct" minOccurs="0" maxOccurs="unbounded">
-                    <xs:complexType>
-                        <xs:all>
-                            <xs:element name="Name" type="xs:string"/>
-                            <xs:element name="Status" minOccurs="0" type="statusType"/>
-                        </xs:all>
-                    </xs:complexType>
-                </xs:element>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-
-    <xs:complexType name="ApiProductNamesType">
-        <xs:sequence>
-            <xs:element name="ApiProduct" maxOccurs="unbounded" type="xs:string" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:simpleType name="statusType">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="approved"/>
-            <xs:enumeration value="revoked"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+<xs:schema xmlns="http://www.apigee.com/oauth/developer_apps" xmlns:common="http://www.apigee.com/oauth/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/oauth/developer_apps" elementFormDefault="qualified">
+	<xs:import namespace="http://www.apigee.com/oauth/common" schemaLocation="common_definitions.xsd"/>
+	<xs:element name="Apps">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="App" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="App">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="AccessType" type="xs:string"/>
+				<xs:element name="CallbackUrl" type="xs:string"/>
+				<xs:element ref="ApiProducts" minOccurs="0"/>
+				<xs:element ref="Credentials" minOccurs="0"/>
+				<xs:element ref="common:Attributes" minOccurs="0"/>
+				<xs:element name="developerEmail" type="xs:string" minOccurs="0"/>
+				<xs:element name="Status" type="statusType" minOccurs="0"/>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:all>
+			<xs:attribute name="name" type="xs:string" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Credentials">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Credential" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Credential">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="ConsumerKey" type="xs:string"/>
+				<xs:element name="ConsumerSecret" type="xs:string"/>
+				<xs:element ref="ApiProducts"/>
+				<xs:element name="Status" type="statusType" minOccurs="0"/>
+				<xs:element ref="common:Attributes" minOccurs="0"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="CredentialRequest">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="ConsumerKey" type="xs:string"/>
+				<xs:element name="Status" type="statusType" minOccurs="0"/>
+				<xs:element ref="common:Attributes" minOccurs="0"/>
+				<xs:element name="ApiProducts" type="ApiProductNamesType" minOccurs="0"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ApiProducts">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="ApiProduct" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:all>
+							<xs:element name="Name" type="xs:string"/>
+							<xs:element name="Status" type="statusType" minOccurs="0"/>
+						</xs:all>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="ApiProductNamesType">
+		<xs:sequence>
+			<xs:element name="ApiProduct" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="statusType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="approved"/>
+			<xs:enumeration value="revoked"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/oauth/developers.xsd
+++ b/schemas/oauth/developers.xsd
@@ -4,51 +4,45 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-    <xs:include schemaLocation="common_definitions.xsd"/>
-
-    <xs:element name="Developers">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="Developer" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Developer">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="Email" type="xs:string"/>
-                <xs:element name="FirstName" type="xs:string"/>
-                <xs:element name="LastName" type="xs:string"/>
-                <xs:element name="UserName" type="xs:string"/>
-                <xs:element ref="Apps" minOccurs="0"/>
-                <xs:element name="OrganizationName" minOccurs="0" type="xs:string"/>
-                <xs:element name="Status" minOccurs="0" type="developerStatus"/>
-                <xs:element ref="Attributes" minOccurs="0"/>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:all>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Apps">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="App" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:simpleType name="developerStatus">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="active"/>
-            <xs:enumeration value="inactive"/>
-            <xs:enumeration value="login_lock"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+<xs:schema xmlns="http://www.apigee.com/oauth/developers" xmlns:common="http://www.apigee.com/oauth/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/oauth/developers" elementFormDefault="qualified">
+	<xs:import namespace="http://www.apigee.com/oauth/common" schemaLocation="common_definitions.xsd"/>
+	<xs:element name="Developers">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Developer" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Developer">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="Email" type="xs:string"/>
+				<xs:element name="FirstName" type="xs:string"/>
+				<xs:element name="LastName" type="xs:string"/>
+				<xs:element name="UserName" type="xs:string"/>
+				<xs:element ref="Apps" minOccurs="0"/>
+				<xs:element name="OrganizationName" type="xs:string" minOccurs="0"/>
+				<xs:element name="Status" type="developerStatus" minOccurs="0"/>
+				<xs:element ref="common:Attributes" minOccurs="0"/>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Apps">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="App" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="developerStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="active"/>
+			<xs:enumeration value="inactive"/>
+			<xs:enumeration value="login_lock"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/oauth/maps.xsd
+++ b/schemas/oauth/maps.xsd
@@ -4,29 +4,25 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-
-    <xs:element name="Maps">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="Map" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Map">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element maxOccurs="unbounded" minOccurs="1" ref="Entry"/>
-            </xs:sequence>
-            <xs:attribute name="name" use="required" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Entry">
-        <xs:complexType mixed="true">
-            <xs:attribute name="name" use="required" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
+<xs:schema targetNamespace="http://www.apigee.com/oauth/map" xmlns="http://www.apigee.com/oauth/map" xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:element name="Maps">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Map" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Map">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Entry" minOccurs="1" maxOccurs="unbounded"/>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:string" use="required"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Entry">
+		<xs:complexType mixed="true">
+			<xs:attribute name="name" type="xs:string" use="required"/>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/oauth/oauthv1.xsd
+++ b/schemas/oauth/oauthv1.xsd
@@ -1,104 +1,95 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-    <xs:include schemaLocation="common_definitions.xsd"/>
-
-    <xs:element name="RequestTokens">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="RequestToken" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-
-    </xs:element>
-
-    <xs:element name="RequestToken">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="Scope" type="xs:string"/>
-                <xs:element name="CallbackUrl" type="xs:string"/>
-                <xs:element name="App" minOccurs="0" type="xs:string"/>
-                <xs:element ref="Attributes" minOccurs="0"/>
-                <xs:element name="ConsumerKey" minOccurs="0" type="xs:string"/>
-                <xs:element name="ExpiresAt" minOccurs="0" type="xs:long"/>
-                <xs:element name="IssuedAt" minOccurs="0" type="xs:long"/>
-                <xs:element name="Secret" minOccurs="0" type="xs:string"/>
-                <xs:element name="Token" minOccurs="0" type="xs:string"/>
-                <xs:element name="Status" minOccurs="0" type="oauthv1TokenStatus"/>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:all>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Verifiers">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="Verifier" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Verifier">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="AppUserId" type="xs:string"/>
-                <xs:element ref="Attributes"/>
-                <xs:element name="ExpiresAt" type="xs:long"/>
-                <xs:element name="IssuedAt" type="xs:long"/>
-                <xs:element name="RequestToken" type="xs:string"/>
-                <xs:element name="Code" type="xs:integer"/>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:all>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="AccessTokens">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="AccessToken" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="AccessToken">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="Scope" type="xs:string"/>
-                <xs:element name="Token" minOccurs="0" type="xs:string"/>
-                <xs:element name="Secret" minOccurs="0" type="xs:string"/>
-                <xs:element name="App" minOccurs="0" type="xs:string"/>
-                <xs:element ref="Attributes" minOccurs="0"/>
-                <xs:element name="ConsumerKey" minOccurs="0" type="xs:string"/>
-                <xs:element name="AppUserId" minOccurs="0" type="xs:string"/>
-                <xs:element name="ExpiresAt" minOccurs="0" type="xs:long"/>
-                <xs:element name="IssuedAt" minOccurs="0" type="xs:long"/>
-                <xs:element name="Status" minOccurs="0" type="oauthv1TokenStatus"/>
-                <xs:element name="Verifier" minOccurs="0" type="xs:string"/>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:all>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:simpleType name="oauthv1TokenStatus">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="approved"/>
-            <xs:enumeration value="revoked"/>
-            <xs:enumeration value="expired"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+<xs:schema xmlns="http://www.apigee.com/oauth/v1" xmlns:common="http://www.apigee.com/oauth/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/oauth/v1" elementFormDefault="qualified">
+	<xs:import namespace="http://www.apigee.com/oauth/common" schemaLocation="common_definitions.xsd"/>
+	<xs:element name="RequestTokens">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="RequestToken" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="RequestToken">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="Scope" type="xs:string"/>
+				<xs:element name="CallbackUrl" type="xs:string"/>
+				<xs:element name="App" type="xs:string" minOccurs="0"/>
+				<xs:element ref="common:Attributes" minOccurs="0"/>
+				<xs:element name="ConsumerKey" type="xs:string" minOccurs="0"/>
+				<xs:element name="ExpiresAt" type="xs:long" minOccurs="0"/>
+				<xs:element name="IssuedAt" type="xs:long" minOccurs="0"/>
+				<xs:element name="Secret" type="xs:string" minOccurs="0"/>
+				<xs:element name="Token" type="xs:string" minOccurs="0"/>
+				<xs:element name="Status" type="oauthv1TokenStatus" minOccurs="0"/>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Verifiers">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="Verifier" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Verifier">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="AppUserId" type="xs:string"/>
+				<xs:element ref="common:Attributes"/>
+				<xs:element name="ExpiresAt" type="xs:long"/>
+				<xs:element name="IssuedAt" type="xs:long"/>
+				<xs:element name="RequestToken" type="xs:string"/>
+				<xs:element name="Code" type="xs:integer"/>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AccessTokens">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AccessToken" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AccessToken">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="Scope" type="xs:string"/>
+				<xs:element name="Token" type="xs:string" minOccurs="0"/>
+				<xs:element name="Secret" type="xs:string" minOccurs="0"/>
+				<xs:element name="App" type="xs:string" minOccurs="0"/>
+				<xs:element ref="common:Attributes" minOccurs="0"/>
+				<xs:element name="ConsumerKey" type="xs:string" minOccurs="0"/>
+				<xs:element name="AppUserId" type="xs:string" minOccurs="0"/>
+				<xs:element name="ExpiresAt" type="xs:long" minOccurs="0"/>
+				<xs:element name="IssuedAt" type="xs:long" minOccurs="0"/>
+				<xs:element name="Status" type="oauthv1TokenStatus" minOccurs="0"/>
+				<xs:element name="Verifier" type="xs:string" minOccurs="0"/>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="oauthv1TokenStatus">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="approved"/>
+			<xs:enumeration value="revoked"/>
+			<xs:enumeration value="expired"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/oauth/oauthv2.xsd
+++ b/schemas/oauth/oauthv2.xsd
@@ -1,100 +1,95 @@
+<!-- edited with XMLSpy v2014 rel. 2 sp1 (x64) (http://www.altova.com) by Ben Madore (private) -->
 <!--
   ~ Copyright (c) 2013, Apigee Corporation.  All rights reserved.
   ~ Apigee(TM) and the Apigee logo are trademarks or
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-    <xs:include schemaLocation="common_definitions.xsd"/>
-
-    <xs:element name="AuthorizationCodes">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="AuthorizationCode" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="AuthorizationCode">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="Attributes"/>
-                <xs:element name="ClientId" type="xs:string"/>
-                <xs:element name="Code" type="xs:string"/>
-                <xs:element name="ExpiresAt" type="xs:long"/>
-                <xs:element name="IssuedAt" type="xs:long"/>
-                <xs:element name="RedirectUri" type="xs:string"/>
-                <xs:element name="Scope" type="xs:string"/>
-                <xs:element name="Status">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="active"/>
-                            <xs:enumeration value="expired"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="AccessTokens">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element ref="AccessToken" minOccurs="0" maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="AccessToken">
-        <xs:complexType>
-            <xs:all>
-                <xs:element name="Scope" type="xs:string"/>
-                <xs:element name="Token" minOccurs="0" type="xs:string"/>
-                <xs:element name="TokenSecret" minOccurs="0" type="xs:string"/>
-                <xs:element name="App" minOccurs="0" type="xs:string"/>
-                <xs:element ref="Attributes" minOccurs="0"/>
-                <xs:element name="ClientId" minOccurs="0" type="xs:string"/>
-                <xs:element name="ExpiresAt" minOccurs="0" type="xs:long"/>
-                <xs:element name="IssuedAt" minOccurs="0" type="xs:long"/>
-                <xs:element name="refreshCount" minOccurs="0" type="xs:integer"/>
-                <xs:element name="GrantType">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="password"/>
-                            <xs:enumeration value="authorization_code"/>
-                            <xs:enumeration value="client_credentials"/>
-                            <xs:enumeration value="implicit"/>
-                            <xs:enumeration value="refresh_token"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="Status">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="approved"/>
-                            <xs:enumeration value="revoked"/>
-                            <xs:enumeration value="expired"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="TokenType">
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="BearerToken"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:element>
-                <xs:element name="CreatedAt" type="xs:long"/>
-                <xs:element name="CreatedBy" type="xs:string"/>
-                <xs:element name="LastModifiedAt" type="xs:long"/>
-                <xs:element name="LastModifiedBy" type="xs:string"/>
-            </xs:all>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/oauth/v2" xmlns:common="http://www.apigee.com/oauth/common" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/oauth/v2" elementFormDefault="qualified">
+	<xs:import namespace="http://www.apigee.com/oauth/common" schemaLocation="common_definitions.xsd"/>
+	<xs:element name="AuthorizationCodes">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AuthorizationCode" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AuthorizationCode">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="common:Attributes"/>
+				<xs:element name="ClientId" type="xs:string"/>
+				<xs:element name="Code" type="xs:string"/>
+				<xs:element name="ExpiresAt" type="xs:long"/>
+				<xs:element name="IssuedAt" type="xs:long"/>
+				<xs:element name="RedirectUri" type="xs:string"/>
+				<xs:element name="Scope" type="xs:string"/>
+				<xs:element name="Status">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="active"/>
+							<xs:enumeration value="expired"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AccessTokens">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element ref="AccessToken" minOccurs="0" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="AccessToken">
+		<xs:complexType>
+			<xs:all>
+				<xs:element name="Scope" type="xs:string"/>
+				<xs:element name="Token" type="xs:string" minOccurs="0"/>
+				<xs:element name="TokenSecret" type="xs:string" minOccurs="0"/>
+				<xs:element name="App" type="xs:string" minOccurs="0"/>
+				<xs:element ref="common:Attributes" minOccurs="0"/>
+				<xs:element name="ClientId" type="xs:string" minOccurs="0"/>
+				<xs:element name="ExpiresAt" type="xs:long" minOccurs="0"/>
+				<xs:element name="IssuedAt" type="xs:long" minOccurs="0"/>
+				<xs:element name="refreshCount" type="xs:integer" minOccurs="0"/>
+				<xs:element name="GrantType">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="password"/>
+							<xs:enumeration value="authorization_code"/>
+							<xs:enumeration value="client_credentials"/>
+							<xs:enumeration value="implicit"/>
+							<xs:enumeration value="refresh_token"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="Status">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="approved"/>
+							<xs:enumeration value="revoked"/>
+							<xs:enumeration value="expired"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="TokenType">
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="BearerToken"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="CreatedAt" type="xs:long"/>
+				<xs:element name="CreatedBy" type="xs:string"/>
+				<xs:element name="LastModifiedAt" type="xs:long"/>
+				<xs:element name="LastModifiedBy" type="xs:string"/>
+			</xs:all>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/ConcurrentRatelimit.xsd
+++ b/schemas/policy/ConcurrentRatelimit.xsd
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:element name="ConcurrentRatelimit">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="AllowConnections">
-                    <xs:complexType>
-                        <xs:attribute type="xs:string" name="count"/>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element type="xs:boolean" name="Distributed" default="false"/>
-                <xs:element name="TargetIdentifier">
-                    <xs:complexType>
-                        <xs:attribute type="xs:string" name="name"/>
-                        <xs:attribute type="xs:string" name="ref"/>
-                    </xs:complexType>
-                </xs:element>
-            </xs:sequence>
-            <xs:attribute type="xs:string" name="name"/>
-        </xs:complexType>
-    </xs:element>
+<xs:schema xmlns="http://www.apigee.com/policy/rate_limit" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/rate_limit" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:element name="ConcurrentRatelimit">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="AllowConnections">
+					<xs:complexType>
+						<xs:attribute name="count" type="xs:string"/>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Distributed" type="xs:boolean" default="false"/>
+				<xs:element name="TargetIdentifier">
+					<xs:complexType>
+						<xs:attribute name="name" type="xs:string"/>
+						<xs:attribute name="ref" type="xs:string"/>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+			<xs:attribute name="name" type="xs:string"/>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/SetOAuthV2Info.xsd
+++ b/schemas/policy/SetOAuthV2Info.xsd
@@ -1,39 +1,39 @@
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:element name="SetOAuthV2Info">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="AccessToken">
-                          <xs:complexType>
-                            <xs:simpleContent>
-                              <xs:extension base="xs:string">
-                                <xs:attribute type="xs:string" name="ref"/>
-                              </xs:extension>
-                            </xs:simpleContent>
-                          </xs:complexType>
-                        </xs:element>
-                        <xs:element name="Attributes">
-                          <xs:complexType>
-                            <xs:sequence>
-                              <xs:element name="Attribute" maxOccurs="unbounded" minOccurs="1">
-                                <xs:complexType>
-                                  <xs:simpleContent>
-                                    <xs:extension base="xs:string">
-                                    <!-- reference takes priority when both value and reference are present-->
-                                      <xs:attribute type="xs:string" name="name" use="optional"/>
-                                      <xs:attribute type="xs:string" name="ref" use="optional"/>
-                                    </xs:extension>
-                                  </xs:simpleContent>
-                                </xs:complexType>
-                              </xs:element>
-                            </xs:sequence>
-                          </xs:complexType>
-                        </xs:element>                         
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
+<xs:schema xmlns="http://www.apigee.com/policy/oauth_v2" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/oauth_v2">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="SetOAuthV2Info">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="AccessToken">
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="xs:string">
+										<xs:attribute name="ref" type="xs:string"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Attributes">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Attribute" minOccurs="1" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:simpleContent>
+												<xs:extension base="xs:string">
+													<xs:attribute name="name" type="xs:string" use="optional"/>
+													<xs:attribute name="ref" type="xs:string" use="optional"/>
+												</xs:extension>
+												<!-- reference takes priority when both value and reference are present-->
+											</xs:simpleContent>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/access_control.xsd
+++ b/schemas/policy/access_control.xsd
@@ -4,49 +4,45 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="AccessControl">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="IPRules" minOccurs="1">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="MatchRule" minOccurs="0" maxOccurs="unbounded">
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="SourceAddress" minOccurs="0" maxOccurs="unbounded">
-                                                    <xs:complexType>
-                                                        <xs:simpleContent>
-                                                            <xs:extension base="xs:string">
-                                                                <xs:attribute name="mask" type="xs:int" default="32"/>
-                                                            </xs:extension>
-                                                        </xs:simpleContent>
-                                                    </xs:complexType>
-                                                </xs:element>
-                                            </xs:sequence>
-                                            <xs:attribute name="action" type="actionType" default="ALLOW"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                                <xs:attribute name="noRuleMatchAction" type="actionType" default="ALLOW"/>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:simpleType name="actionType">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="ALLOW"/>
-            <xs:enumeration value="DENY"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+<xs:schema xmlns="http://www.apigee.com/policy/access_control" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:step="http://www.apigee.com/policy/step" targetNamespace="http://www.apigee.com/policy/access_control">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="AccessControl">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="IPRules" minOccurs="1">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="MatchRule" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SourceAddress" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:simpleContent>
+															<xs:extension base="xs:string">
+																<xs:attribute name="mask" type="xs:int" default="32"/>
+															</xs:extension>
+														</xs:simpleContent>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="action" type="actionType" default="ALLOW"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="noRuleMatchAction" type="actionType" default="ALLOW"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:simpleType name="actionType">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="ALLOW"/>
+			<xs:enumeration value="DENY"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/policy/access_entity.xsd
+++ b/schemas/policy/access_entity.xsd
@@ -5,65 +5,55 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="AccessEntity" type="accessEntityBean"/>
-
-    <xs:complexType name="entityIdentifier">
-        <xs:sequence/>
-        <xs:attribute name="ref" type="xs:string" use="required"/>
-        <xs:attribute name="type" type="xs:string"/>
-    </xs:complexType>
-
-    <xs:complexType name="secondaryIdentifier">
-        <xs:sequence/>
-        <xs:attribute name="ref" type="xs:string" use="required"/>
-        <xs:attribute name="type" type="xs:string"/>
-    </xs:complexType>
-
-    <xs:complexType name="entityType">
-        <xs:sequence/>
-        <xs:attribute name="value" type="xs:string" use="required"/>
-    </xs:complexType>
-
-    <xs:complexType name="accessEntityBean">
-        <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
-                <xs:sequence>
-                    <xs:element name="EntityIdentifier" type="entityIdentifier" minOccurs="0"/>
-                    <xs:element name="EntityType" type="entityType" minOccurs="0"/>
-                    <xs:element name="Identifiers" minOccurs="0">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Identifier" type="compositeIdentifier" minOccurs="0" maxOccurs="unbounded"/>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="SecondaryIdentifier" type="secondaryIdentifier" minOccurs="0"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="compositeIdentifier">
-        <xs:sequence>
-            <xs:element name="EntityIdentifier" type="entityIdentifier" minOccurs="0"/>
-            <xs:element name="SecondaryIdentifier" type="secondaryIdentifier" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:simpleType name="entityTypes">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="developer"/>
-            <xs:enumeration value="app"/>
-            <xs:enumeration value="apiproduct"/>
-            <xs:enumeration value="company"/>
-            <xs:enumeration value="companydeveloper"/>
-            <xs:enumeration value="consumerkey"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+<xs:schema xmlns="http://www.apigee.com/policy/access_entity" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:step="http://www.apigee.com/policy/step" targetNamespace="http://www.apigee.com/policy/access_entity" version="1.0">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="AccessEntity" type="accessEntityBean"/>
+	<xs:complexType name="entityIdentifier">
+		<xs:sequence/>
+		<xs:attribute name="ref" type="xs:string" use="required"/>
+		<xs:attribute name="type" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="secondaryIdentifier">
+		<xs:sequence/>
+		<xs:attribute name="ref" type="xs:string" use="required"/>
+		<xs:attribute name="type" type="xs:string"/>
+	</xs:complexType>
+	<xs:complexType name="entityType">
+		<xs:sequence/>
+		<xs:attribute name="value" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="accessEntityBean">
+		<xs:complexContent>
+			<xs:extension base="step:stepDefinitionType">
+				<xs:sequence>
+					<xs:element name="EntityIdentifier" type="entityIdentifier" minOccurs="0"/>
+					<xs:element name="EntityType" type="entityType" minOccurs="0"/>
+					<xs:element name="Identifiers" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Identifier" type="compositeIdentifier" minOccurs="0" maxOccurs="unbounded"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="SecondaryIdentifier" type="secondaryIdentifier" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="compositeIdentifier">
+		<xs:sequence>
+			<xs:element name="EntityIdentifier" type="entityIdentifier" minOccurs="0"/>
+			<xs:element name="SecondaryIdentifier" type="secondaryIdentifier" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="entityTypes">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="developer"/>
+			<xs:enumeration value="app"/>
+			<xs:enumeration value="apiproduct"/>
+			<xs:enumeration value="company"/>
+			<xs:enumeration value="companydeveloper"/>
+			<xs:enumeration value="consumerkey"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/policy/all.xsd
+++ b/schemas/policy/all.xsd
@@ -5,7 +5,7 @@
   ~ trademarks are the property of their respective owners.
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns="http://www.apigee.com/policy/all" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="access_control.xsd"/>
     <xs:include schemaLocation="assign_message.xsd"/>
     <xs:include schemaLocation="cache.xsd"/>

--- a/schemas/policy/assign_message.xsd
+++ b/schemas/policy/assign_message.xsd
@@ -5,18 +5,18 @@
   ~ trademarks are the property of their respective owners.
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
+<xs:schema targetNamespace="http://www.apigee.com/policy/assign_message" xmlns="http://www.apigee.com/policy/assign_message" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
 
     <xs:element name="AssignMessage">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
+                <xs:extension base="step:stepDefinitionType">
                     <xs:sequence>
                         <xs:element name="AssignTo" minOccurs="0">
                             <xs:complexType>
                                 <xs:simpleContent>
-                                    <xs:extension base="variable">
+                                    <xs:extension base="step:variable">
                                         <xs:attribute name="createNew" type="xs:boolean"/>
                                         <xs:attribute name="type" default="request">
                                             <xs:simpleType>
@@ -54,7 +54,7 @@
                     <xs:element name="StatusCode" minOccurs="0" type="xs:boolean"/>
                     <xs:element name="ReasonPhrase" minOccurs="0" type="xs:boolean"/>
                 </xs:sequence>
-                <xs:attribute name="source" type="variable" use="required"/>
+                <xs:attribute name="source" type="step:variable" use="required"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -68,14 +68,14 @@
                             <xs:sequence>
                                 <xs:any minOccurs="0" maxOccurs="unbounded"/>
                             </xs:sequence>
-                            <xs:attribute name="contentType" type="template" use="optional"/>
+                            <xs:attribute name="contentType" type="step:template" use="optional"/>
                         </xs:complexType>
                     </xs:element>
-                    <xs:element name="Verb" minOccurs="0" type="template"/>
-                    <xs:element name="Version" minOccurs="0" type="template"/>
-                    <xs:element name="Path" minOccurs="0" type="template"/>
-                    <xs:element name="StatusCode" minOccurs="0" type="template"/>
-                    <xs:element name="ReasonPhrase" minOccurs="0" type="template"/>
+                    <xs:element name="Verb" minOccurs="0" type="step:template"/>
+                    <xs:element name="Version" minOccurs="0" type="step:template"/>
+                    <xs:element name="Path" minOccurs="0" type="step:template"/>
+                    <xs:element name="StatusCode" minOccurs="0" type="step:template"/>
+                    <xs:element name="ReasonPhrase" minOccurs="0" type="step:template"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -136,7 +136,7 @@
 
     <xs:complexType name="nameValueType">
         <xs:simpleContent>
-            <xs:extension base="template">
+            <xs:extension base="step:template">
                 <xs:attribute name="name" type="xs:string" use="required"/>
             </xs:extension>
         </xs:simpleContent>

--- a/schemas/policy/basic_authentication.xsd
+++ b/schemas/policy/basic_authentication.xsd
@@ -4,51 +4,42 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           elementFormDefault="qualified">
-
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:complexType name="assignTo">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="createNew" type="xs:boolean"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-
-    <xs:element name="BasicAuthentication" type="basicAuthStepDefinitionBean"/>
-
-    <xs:complexType name="BasicAuthenticationUser">
-        <xs:sequence/>
-        <xs:attribute name="ref" type="xs:string" use="required"/>
-    </xs:complexType>
-
-    <xs:complexType name="BasicAuthenticationPassword">
-        <xs:sequence/>
-        <xs:attribute name="ref" type="xs:string" use="required"/>
-    </xs:complexType>
-
-    <xs:complexType name="basicAuthStepDefinitionBean">
-        <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
-                <xs:sequence>
-                    <xs:element name="AssignTo" type="assignTo" minOccurs="0"/>
-                    <xs:element name="IgnoreUnresolvedVariables" type="xs:boolean"/>
-                    <xs:element name="Operation" type="Operation"/>
-                    <xs:element name="Password" type="BasicAuthenticationPassword"/>
-                    <xs:element name="User" type="BasicAuthenticationUser"/>
-                    <xs:element name="Source" type="xs:string" minOccurs="0"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:simpleType name="Operation">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="Encode"/>
-            <xs:enumeration value="Decode"/>
-        </xs:restriction>
-    </xs:simpleType>
-
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.apigee.com/policy/basic_auth" xmlns:step="http://www.apigee.com/policy/step" targetNamespace="http://www.apigee.com/policy/basic_auth" elementFormDefault="qualified">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:complexType name="assignTo">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="createNew" type="xs:boolean"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:element name="BasicAuthentication" type="basicAuthStepDefinitionBean"/>
+	<xs:complexType name="BasicAuthenticationUser">
+		<xs:sequence/>
+		<xs:attribute name="ref" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="BasicAuthenticationPassword">
+		<xs:sequence/>
+		<xs:attribute name="ref" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="basicAuthStepDefinitionBean">
+		<xs:complexContent>
+			<xs:extension base="step:stepDefinitionType">
+				<xs:sequence>
+					<xs:element name="AssignTo" type="assignTo" minOccurs="0"/>
+					<xs:element name="IgnoreUnresolvedVariables" type="xs:boolean"/>
+					<xs:element name="Operation" type="Operation"/>
+					<xs:element name="Password" type="BasicAuthenticationPassword"/>
+					<xs:element name="User" type="BasicAuthenticationUser"/>
+					<xs:element name="Source" type="xs:string" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="Operation">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Encode"/>
+			<xs:enumeration value="Decode"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schemas/policy/cache.xsd
+++ b/schemas/policy/cache.xsd
@@ -5,14 +5,14 @@
   ~ trademarks are the property of their respective owners.
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../configuration/properties.xsd"/>
+<xs:schema targetNamespace="http://www.apigee.com/policy/cache" xmlns="http://www.apigee.com/policy/cache" xmlns:step="http://www.apigee.com/policy/step" xmlns:prop="http://www.apigee.com/configuration/properties" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+    <xs:import namespace="http://www.apigee.com/configuration/properties" schemaLocation="../configuration/properties.xsd"/>
 
     <xs:element name="LookupCache">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="cacheStepDefinitionType">
+                <xs:extension base="cachestepDefinitionType">
                     <xs:sequence>
                         <xs:element name="AssignTo" type="xs:NCName"/>
                     </xs:sequence>
@@ -24,7 +24,7 @@
     <xs:element name="PopulateCache">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="cacheStepDefinitionType">
+                <xs:extension base="cachestepDefinitionType">
                     <xs:sequence>
                         <xs:element name="Source" type="xs:NCName"/>
                         <xs:element ref="ExpirySettings" minOccurs="0"/>
@@ -37,14 +37,14 @@
     <xs:element name="InvalidateCache">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="cacheStepDefinitionType">
+                <xs:extension base="cachestepDefinitionType">
                     <xs:sequence>
                         <xs:element name="CacheContext" minOccurs="0">
                             <xs:complexType>
                                 <xs:sequence>
-                                    <xs:element name="ApplicationName" type="propertyType" minOccurs="0"/>
-                                    <xs:element name="TargetName" type="propertyType" minOccurs="0"/>
-                                    <xs:element name="ProxyName" type="propertyType" minOccurs="0"/>
+                                    <xs:element name="ApplicationName" type="prop:propertyType" minOccurs="0"/>
+                                    <xs:element name="TargetName" type="prop:propertyType" minOccurs="0"/>
+                                    <xs:element name="ProxyName" type="prop:propertyType" minOccurs="0"/>
                                 </xs:sequence>
                             </xs:complexType>
                         </xs:element>
@@ -58,7 +58,7 @@
     <xs:element name="ResponseCache">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="cacheStepDefinitionType">
+                <xs:extension base="cachestepDefinitionType">
                     <xs:sequence>
                         <xs:element name="SkipCacheLookup" type="xs:string" minOccurs="0"/>
                         <xs:element name="SkipCachePopulation" type="xs:string" minOccurs="0"/>
@@ -69,9 +69,9 @@
         </xs:complexType>
     </xs:element>
 
-    <xs:complexType name="cacheStepDefinitionType">
+    <xs:complexType name="cachestepDefinitionType">
         <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
+            <xs:extension base="step:stepDefinitionType">
                 <xs:sequence>
                     <xs:element name="CacheResource" type="xs:NCName"/>
                     <xs:element name="Scope">
@@ -89,7 +89,7 @@
                         <xs:complexType>
                             <xs:sequence>
                                 <xs:element name="Prefix" type="xs:string" minOccurs="0"/>
-                                <xs:element name="KeyFragment" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+                                <xs:element name="KeyFragment" type="prop:propertyType" minOccurs="0" maxOccurs="unbounded"/>
                             </xs:sequence>
                         </xs:complexType>
                     </xs:element>
@@ -101,9 +101,9 @@
     <xs:element name="ExpirySettings">
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="TimeOfDay" type="propertyType" minOccurs="0"/>
-                <xs:element name="TimeoutInSec" type="propertyType" minOccurs="0"/>
-                <xs:element name="ExpiryDate" type="propertyType" minOccurs="0"/>
+                <xs:element name="TimeOfDay" type="prop:propertyType" minOccurs="0"/>
+                <xs:element name="TimeoutInSec" type="prop:propertyType" minOccurs="0"/>
+                <xs:element name="ExpiryDate" type="prop:propertyType" minOccurs="0"/>
             </xs:sequence>
         </xs:complexType>
     </xs:element>

--- a/schemas/policy/cache.xsd
+++ b/schemas/policy/cache.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../properties.xsd"/>
+    <xs:include schemaLocation="../configuration/properties.xsd"/>
 
     <xs:element name="LookupCache">
         <xs:complexType>

--- a/schemas/policy/extract_variables.xsd
+++ b/schemas/policy/extract_variables.xsd
@@ -5,13 +5,12 @@
   ~ trademarks are the property of their respective owners.
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
+<xs:schema targetNamespace="http://www.apigee.com/policy/extract_variables"  xmlns="http://www.apigee.com/policy/extract_variables"  xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+    <xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
     <xs:element name="ExtractVariables">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
+                <xs:extension base="step:stepDefinitionType">
                     <xs:sequence>
                         <xs:element name="Source" minOccurs="0" type="xs:string"/>
                         <xs:element name="VariablePrefix" type="xs:string" minOccurs="0"/>
@@ -29,7 +28,7 @@
                             <xs:element name="QueryParam" type="extractNamedPatternsType"/>
                             <xs:element name="Header" type="extractNamedPatternsType"/>
                             <xs:element name="FormParam" type="extractNamedPatternsType"/>
-                            <xs:element name="Variable" type="extractNamedPatternsType"/>
+                            <xs:element name="variable" type="extractNamedPatternsType"/>
                         </xs:choice>
                         <xs:element name="XMLPayload" minOccurs="0">
                             <xs:complexType>
@@ -50,7 +49,7 @@
                                             </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>
-                                    <xs:element name="Variable" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="variable" minOccurs="0" maxOccurs="unbounded">
                                         <xs:complexType>
                                             <xs:sequence>
                                                 <xs:element name="XPath" type="xs:string" maxOccurs="unbounded"/>
@@ -78,7 +77,7 @@
                         <xs:element name="JSONPayload" minOccurs="0">
                             <xs:complexType>
                                 <xs:sequence>
-                                    <xs:element name="Variable" minOccurs="0" maxOccurs="unbounded">
+                                    <xs:element name="variable" minOccurs="0" maxOccurs="unbounded">
                                         <xs:complexType>
                                             <xs:sequence>
                                                 <xs:element name="JSONPath" type="xs:string" maxOccurs="unbounded"/>

--- a/schemas/policy/java_callout.xsd
+++ b/schemas/policy/java_callout.xsd
@@ -4,25 +4,22 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="JavaCallout">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="ResourceURL" type="xs:string">
-                            <xs:annotation>
-                                <xs:documentation>only resource of type java is allowed</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="ClassName" type="xs:string"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema targetNamespace= "http://www.apigee.com/policy/java_callout" xmlns="http://www.apigee.com/policy/java_callout" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd" />
+	<xs:element name="JavaCallout">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="ResourceURL" type="xs:string">
+							<xs:annotation>
+								<xs:documentation>only resource of type java is allowed</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ClassName" type="xs:string"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/java_script.xsd
+++ b/schemas/policy/java_script.xsd
@@ -5,23 +5,18 @@
 ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
 ~ trademarks are the property of their respective owners.
 -->
-
-<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="Javascript" type="javascriptBean"/>
-
-    <xs:complexType name="javascriptBean">
-        <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
-                <xs:sequence>
-                    <xs:element name="IncludeURL" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-                    <xs:element name="ResourceURL" type="xs:string"/>
-                </xs:sequence>
-                <xs:attribute name="timeLimit" type="xs:long" use="required"/>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
+<xs:schema xmlns="http://www.apigee.com/policy/javascript" xmlns:xs="http://www.w3.org/2001/XMLSchema"  xmlns:step="http://www.apigee.com/policy/step" targetNamespace="http://www.apigee.com/policy/javascript" version="1.0">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="Javascript" type="javascriptBean"/>
+	<xs:complexType name="javascriptBean">
+		<xs:complexContent>
+			<xs:extension base="step:stepDefinitionType">
+				<xs:sequence>
+					<xs:element name="IncludeURL" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="ResourceURL" type="xs:string"/>
+				</xs:sequence>
+				<xs:attribute name="timeLimit" type="xs:long" use="required"/>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 </xs:schema>

--- a/schemas/policy/json_threat_protection.xsd
+++ b/schemas/policy/json_threat_protection.xsd
@@ -4,25 +4,22 @@
  ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
  ~ trademarks are the property of their respective owners.
  -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="JSONThreatProtection">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="Source" type="xs:NCName" minOccurs="0"/>
-                        <xs:element name="ContainerDepth" type="xs:int" default="-1" minOccurs="0"/>
-                        <xs:element name="ObjectEntryCount" type="xs:int" default="-1" minOccurs="0"/>
-                        <xs:element name="ArrayElementCount" type="xs:int" default="-1" minOccurs="0"/>
-                        <xs:element name="ObjectEntryNameLength" type="xs:int" default="-1" minOccurs="0"/>
-                        <xs:element name="StringValueLength" type="xs:int" default="-1" minOccurs="0"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/json_threat" xmlns:xs="http://www.w3.org/2001/XMLSchema"  xmlns:step="http://www.apigee.com/policy/step" targetNamespace="http://www.apigee.com/policy/json_threat">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="JSONThreatProtection">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="Source" type="xs:NCName" minOccurs="0"/>
+						<xs:element name="ContainerDepth" type="xs:int" default="-1" minOccurs="0"/>
+						<xs:element name="ObjectEntryCount" type="xs:int" default="-1" minOccurs="0"/>
+						<xs:element name="ArrayElementCount" type="xs:int" default="-1" minOccurs="0"/>
+						<xs:element name="ObjectEntryNameLength" type="xs:int" default="-1" minOccurs="0"/>
+						<xs:element name="StringValueLength" type="xs:int" default="-1" minOccurs="0"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/json_to_xml.xsd
+++ b/schemas/policy/json_to_xml.xsd
@@ -4,46 +4,35 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="JSONToXML">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="Source" type="xs:NCName" default="message" minOccurs="0"/>
-                        <xs:element name="OutputVariable" type="xs:NCName" minOccurs="0"/>
-                        <xs:element name="Options" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="NullValue" type="xs:string" minOccurs="0"/>
-
-                                    <xs:element name="NamespaceBlockName" type="xs:string" minOccurs="0"/>
-                                    <xs:element name="DefaultNamespaceNodeName" type="xs:string" minOccurs="0"/>
-                                    <xs:element name="NamespaceSeparator" type="xs:string" minOccurs="0"/>
-
-                                    <xs:element name="TextNodeName" type="xs:string" minOccurs="0"/>
-
-                                    <xs:element name="AttributeBlockName" type="xs:string" minOccurs="0"/>
-                                    <xs:element name="AttributePrefix" type="xs:string" minOccurs="0"/>
-
-                                    <xs:element name="InvalidCharsReplacement" type="xs:string" minOccurs="0"/>
-
-                                    <xs:element name="ObjectRootElementName" type="xs:NCName" minOccurs="0"
-                                                default="Root"/>
-                                    <xs:element name="ArrayRootElementName" type="xs:NCName" minOccurs="0"
-                                                default="Array"/>
-                                    <xs:element name="ArrayItemElementName" type="xs:NCName" minOccurs="0"
-                                                default="Item"/>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/json_to_xml"  xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/json_to_xml">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="JSONToXML">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="Source" type="xs:NCName" default="message" minOccurs="0"/>
+						<xs:element name="OutputVariable" type="xs:NCName" minOccurs="0"/>
+						<xs:element name="Options" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="NullValue" type="xs:string" minOccurs="0"/>
+									<xs:element name="NamespaceBlockName" type="xs:string" minOccurs="0"/>
+									<xs:element name="DefaultNamespaceNodeName" type="xs:string" minOccurs="0"/>
+									<xs:element name="NamespaceSeparator" type="xs:string" minOccurs="0"/>
+									<xs:element name="TextNodeName" type="xs:string" minOccurs="0"/>
+									<xs:element name="AttributeBlockName" type="xs:string" minOccurs="0"/>
+									<xs:element name="AttributePrefix" type="xs:string" minOccurs="0"/>
+									<xs:element name="InvalidCharsReplacement" type="xs:string" minOccurs="0"/>
+									<xs:element name="ObjectRootElementName" type="xs:NCName" default="Root" minOccurs="0"/>
+									<xs:element name="ArrayRootElementName" type="xs:NCName" default="Array" minOccurs="0"/>
+									<xs:element name="ArrayItemElementName" type="xs:NCName" default="Item" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/keyvaluemap-operations.xsd
+++ b/schemas/policy/keyvaluemap-operations.xsd
@@ -4,82 +4,73 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../configuration/properties.xsd"/>
-
-    <xs:element name="KeyValueMapOperations">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="ExclusiveCache" minOccurs="0" type="xs:boolean" default="false"/>
-                        <xs:element name="ExpiryTimeInSecs" minOccurs="0" type="xs:int" default="-1"/>
-
-                        <xs:element name="InitialEntries" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="Entry" minOccurs="0" maxOccurs="unbounded">
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="Key">
-                                                    <xs:complexType>
-                                                        <xs:sequence>
-                                                            <xs:element name="Parameter" type="xs:string" minOccurs="1"
-                                                                        maxOccurs="unbounded"/>
-                                                        </xs:sequence>
-                                                    </xs:complexType>
-                                                </xs:element>
-                                                <xs:element name="Value" type="xs:string" minOccurs="1"
-                                                            maxOccurs="unbounded"/>
-                                            </xs:sequence>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-
-                        <xs:choice minOccurs="1" maxOccurs="unbounded">
-                            <xs:element name="Put">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element ref="Key" minOccurs="1"/>
-                                        <xs:element name="Value" type="propertyType" minOccurs="1"
-                                                    maxOccurs="unbounded"/>
-                                    </xs:sequence>
-                                    <xs:attribute name="override" type="xs:boolean" default="false"/>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element name="Get">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element ref="Key" minOccurs="1"/>
-                                    </xs:sequence>
-                                    <xs:attribute name="assignTo" type="xs:string" use="required"/>
-                                    <xs:attribute name="index" type="xs:int" use="optional"/>
-                                </xs:complexType>
-                            </xs:element>
-                            <xs:element name="Delete">
-                                <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:element ref="Key" minOccurs="1"/>
-                                    </xs:sequence>
-                                </xs:complexType>
-                            </xs:element>
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="Key">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Parameter" type="xs:string" minOccurs="1"
-                            maxOccurs="unbounded"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
+<xs:schema xmlns="http://www.apigee.com/policy/kv_map"  xmlns:step="http://www.apigee.com/policy/step"  xmlns:prop="http://www.apigee.com/configuration/properties" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/kv_map">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/properties" schemaLocation="../configuration/properties.xsd"/>
+	<xs:element name="KeyValueMapOperations">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="ExclusiveCache" type="xs:boolean" default="false" minOccurs="0"/>
+						<xs:element name="ExpiryTimeInSecs" type="xs:int" default="-1" minOccurs="0"/>
+						<xs:element name="InitialEntries" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Entry" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Key">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="Parameter" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="Value" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:choice minOccurs="1" maxOccurs="unbounded">
+							<xs:element name="Put">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="Key" minOccurs="1"/>
+										<xs:element name="Value" type="prop:propertyType" minOccurs="1" maxOccurs="unbounded"/>
+									</xs:sequence>
+									<xs:attribute name="override" type="xs:boolean" default="false"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Get">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="Key" minOccurs="1"/>
+									</xs:sequence>
+									<xs:attribute name="assignTo" type="xs:string" use="required"/>
+									<xs:attribute name="index" type="xs:int" use="optional"/>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="Delete">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element ref="Key" minOccurs="1"/>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:choice>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="Key">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Parameter" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/keyvaluemap-operations.xsd
+++ b/schemas/policy/keyvaluemap-operations.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../properties.xsd"/>
+    <xs:include schemaLocation="../configuration/properties.xsd"/>
 
     <xs:element name="KeyValueMapOperations">
         <xs:complexType>

--- a/schemas/policy/message_logging.xsd
+++ b/schemas/policy/message_logging.xsd
@@ -4,24 +4,21 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../configuration/destinations.xsd"/>
-
-    <xs:element name="MessageLogging">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element ref="Destination" maxOccurs="unbounded"/>
-                        <xs:element name="NotificationIntervalInSec" type="xs:int" minOccurs="0" default="0"/>
-                        <xs:element name="IgnoreUnresolvedVariables" type="xs:boolean" minOccurs="0" default="true"/>
-                        <xs:element name="BufferMessage" type="xs:boolean" minOccurs="0" default="false"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/message_logging" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:step="http://www.apigee.com/policy/step" xmlns:destination="http://www.apigee.com/configuration/destinations" targetNamespace="http://www.apigee.com/policy/message_logging">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/destinations" schemaLocation="../configuration/destinations.xsd"/>
+	<xs:element name="MessageLogging">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element ref="destination:Destination" maxOccurs="unbounded"/>
+						<xs:element name="NotificationIntervalInSec" type="xs:int" default="0" minOccurs="0"/>
+						<xs:element name="IgnoreUnresolvedVariables" type="xs:boolean" default="true" minOccurs="0"/>
+						<xs:element name="BufferMessage" type="xs:boolean" default="false" minOccurs="0"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/message_logging.xsd
+++ b/schemas/policy/message_logging.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../destinations.xsd"/>
+    <xs:include schemaLocation="../configuration/destinations.xsd"/>
 
     <xs:element name="MessageLogging">
         <xs:complexType>

--- a/schemas/policy/message_validation.xsd
+++ b/schemas/policy/message_validation.xsd
@@ -4,47 +4,44 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="MessageValidation">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="ResourceURL" type="xs:string" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation>only resource of type xsd and wsdl are allowed</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Source" type="xs:NCName" minOccurs="0"/>
-                        <xs:element name="SOAPMessage" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence/>
-                                <xs:attribute name="version">
-                                    <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                            <xs:enumeration value="1.1"/>
-                                            <xs:enumeration value="1.2"/>
-                                        </xs:restriction>
-                                    </xs:simpleType>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="Element" minOccurs="0" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:simpleContent>
-                                    <xs:extension base="xs:NCName">
-                                        <xs:attribute name="namespace" type="xs:string" use="optional"/>
-                                    </xs:extension>
-                                </xs:simpleContent>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/message_validation" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/message_validation">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="MessageValidation">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="ResourceURL" type="xs:string" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>only resource of type xsd and wsdl are allowed</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="Source" type="xs:NCName" minOccurs="0"/>
+						<xs:element name="SOAPMessage" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence/>
+								<xs:attribute name="version">
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:enumeration value="1.1"/>
+											<xs:enumeration value="1.2"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Element" minOccurs="0" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="xs:NCName">
+										<xs:attribute name="namespace" type="xs:string" use="optional"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/oauth.xsd
+++ b/schemas/policy/oauth.xsd
@@ -5,20 +5,20 @@
   ~ trademarks are the property of their respective owners.
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../configuration/properties.xsd"/>
+<xs:schema targetNamespace="http://www.apigee.com/policy/oauth" xmlns="http://www.apigee.com/policy/oauth" xmlns:step="http://www.apigee.com/policy/step" xmlns:prop="http://www.apigee.com/configuration/properties" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+    <xs:import namespace="http://www.apigee.com/configuration/properties" schemaLocation="../configuration/properties.xsd"/>
 
     <xs:element name="GetOAuthV1Info">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
+                <xs:extension base="step:stepDefinitionType">
                     <xs:sequence>
                         <xs:element name="OAuthConfig" type="xs:NCName" minOccurs="0"/>
                         <xs:choice>
-                            <xs:element name="RequestToken" type="propertyType"/>
-                            <xs:element name="AccessToken" type="propertyType"/>
-                            <xs:element name="ConsumerKey" type="propertyType"/>
+                            <xs:element name="RequestToken" type="prop:propertyType"/>
+                            <xs:element name="AccessToken" type="prop:propertyType"/>
+                            <xs:element name="ConsumerKey" type="prop:propertyType"/>
                         </xs:choice>
                     </xs:sequence>
                 </xs:extension>
@@ -29,14 +29,14 @@
     <xs:element name="GetOAuthV2Info">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
+                <xs:extension base="step:stepDefinitionType">
                     <xs:sequence>
                         <xs:element name="OAuthConfig" type="xs:NCName" minOccurs="0"/>
                         <xs:choice>
-                            <xs:element name="RequestToken" type="propertyType"/>
-                            <xs:element name="AccessToken" type="propertyType"/>
-                            <xs:element name="ClientId" type="propertyType"/>
-                            <xs:element name="AuthorizationCode" type="propertyType"/>
+                            <xs:element name="RequestToken" type="prop:propertyType"/>
+                            <xs:element name="AccessToken" type="prop:propertyType"/>
+                            <xs:element name="ClientId" type="prop:propertyType"/>
+                            <xs:element name="AuthorizationCode" type="prop:propertyType"/>
                         </xs:choice>
                     </xs:sequence>
                 </xs:extension>
@@ -47,7 +47,7 @@
     <xs:element name="OAuthV1">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
+                <xs:extension base="step:stepDefinitionType">
                     <xs:sequence>
                         <xs:element name="OAuthConfig" type="xs:NCName" minOccurs="0"/>
                         <xs:element name="Operation">
@@ -81,7 +81,7 @@
     <xs:element name="OAuthV2">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
+                <xs:extension base="step:stepDefinitionType">
                     <xs:sequence>
                         <xs:element name="OAuthConfig" type="xs:NCName" minOccurs="0"/>
                         <xs:element name="Operation">

--- a/schemas/policy/raise_fault.xsd
+++ b/schemas/policy/raise_fault.xsd
@@ -4,34 +4,29 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           elementFormDefault="qualified">
-
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="assign_message.xsd"/>
-
-    <xs:complexType name="raiseFaultType">
-        <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
-                <xs:sequence>
-                    <xs:element name="IgnoreUnresolvedVariables" type="xs:boolean" minOccurs="0" default="true"/>
-                    <xs:element ref="FaultResponse" minOccurs="0"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="faultResponseType">
-        <xs:sequence>
-            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element name="Copy" type="copyType"/>
-                <xs:element name="Remove" type="nameActionType"/>
-                <xs:element name="Add" type="nameValueActionType"/>
-                <xs:element name="Set" type="setType"/>
-            </xs:choice>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:element name="FaultResponse" type="faultResponseType"/>
-    <xs:element name="RaiseFault" type="raiseFaultType" substitutionGroup="StepDefinition"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.apigee.com/policy/raise_fault" xmlns:step="http://www.apigee.com/policy/step" xmlns:assign="http://www.apigee.com/policy/assign_message" targetNamespace="http://www.apigee.com/policy/raise_fault" elementFormDefault="qualified">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:import namespace="http://www.apigee.com/policy/assign_message" schemaLocation="assign_message.xsd"/>
+	<xs:complexType name="raiseFaultType">
+		<xs:complexContent>
+			<xs:extension base="step:stepDefinitionType">
+				<xs:sequence>
+					<xs:element name="IgnoreUnresolvedVariables" type="xs:boolean" default="true" minOccurs="0"/>
+					<xs:element ref="FaultResponse" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="faultResponseType">
+		<xs:sequence>
+			<xs:choice minOccurs="0" maxOccurs="unbounded">
+				<xs:element name="Copy" type="assign:copyType"/>
+				<xs:element name="Remove" type="assign:nameActionType"/>
+				<xs:element name="Add" type="assign:nameValueActionType"/>
+				<xs:element name="Set" type="assign:setType"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="FaultResponse" type="faultResponseType"/>
+	<xs:element name="RaiseFault" type="raiseFaultType" substitutionGroup="step:StepDefinition"/>
 </xs:schema>

--- a/schemas/policy/ratelimit.xsd
+++ b/schemas/policy/ratelimit.xsd
@@ -4,120 +4,110 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../configuration/destinations.xsd"/>
-
-    <xs:element name="Quota">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="ratelimitType">
-                    <xs:sequence>
-                        <xs:element name="Interval" type="intervalType"/>
-                        <xs:element name="Allow">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="Class">
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="Allow" minOccurs="0" maxOccurs="unbounded">
-                                                    <xs:complexType>
-                                                        <xs:sequence/>
-                                                        <xs:attribute name="class" type="xs:string" default="_default"/>
-                                                        <xs:attribute name="count" type="xs:int"/>
-                                                        <xs:attribute name="countRef" type="xs:NCName"/>
-                                                    </xs:complexType>
-                                                </xs:element>
-                                            </xs:sequence>
-                                            <xs:attribute name="ref" type="xs:NCName" use="required"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                                <xs:attribute name="count" type="xs:int"/>
-                                <xs:attribute name="countRef" type="xs:NCName"/>
-                            </xs:complexType>
-                        </xs:element>
-
-                        <xs:element name="Alert">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="NotificationIntervalInSec" type="xs:int" minOccurs="0"/>
-                                    <xs:element ref="Destination" maxOccurs="unbounded"/>
-                                </xs:sequence>
-                                <xs:attribute name="count" type="xs:int" use="required"/>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="SpikeArrest">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="ratelimitType">
-                    <xs:sequence>
-                        <xs:element name="Rate" type="xs:string"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="ResetQuota">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="Quota">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="Identifier" minOccurs="0" maxOccurs="unbounded">
-                                        <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:element name="Class" minOccurs="0" maxOccurs="unbounded">
-                                                    <xs:complexType>
-                                                        <xs:sequence>
-
-                                                        </xs:sequence>
-                                                        <xs:attribute name="name" type="xs:NCName" use="optional"/>
-                                                        <xs:attribute name="ref" type="xs:NCName" use="optional"/>
-                                                        <xs:attribute name="allow" type="xs:long" use="optional"/>
-                                                    </xs:complexType>
-                                                </xs:element>
-                                            </xs:sequence>
-                                            <xs:attribute name="name" type="xs:NCName" use="optional"/>
-                                            <xs:attribute name="ref" type="xs:NCName" use="optional"/>
-                                            <xs:attribute name="allow" type="xs:long" use="optional"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                                <xs:attribute name="name" type="xs:NCName" use="optional"/>
-                                <xs:attribute name="ref" type="xs:NCName" use="optional"/>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="ratelimitType">
-        <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
-                <xs:sequence>
-                    <xs:element name="Identifier" type="refType" minOccurs="0"/>
-                    <xs:element name="MessageWeight" type="refType" minOccurs="0"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="refType">
-        <xs:sequence/>
-        <xs:attribute name="ref" type="xs:NCName" use="required"/>
-    </xs:complexType>
-
+<xs:schema xmlns="http://www.apigee.com/policy/rate_limit" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:step="http://www.apigee.com/policy/step" xmlns:destination="http://www.apigee.com/configuration/destinations" targetNamespace="http://www.apigee.com/policy/rate_limit">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/destinations" schemaLocation="../configuration/destinations.xsd"/>
+	<xs:element name="Quota">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="ratelimitType">
+					<xs:sequence>
+						<xs:element name="Interval" type="destination:intervalType"/>
+						<xs:element name="Allow">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Class">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Allow" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence/>
+														<xs:attribute name="class" type="xs:string" default="_default"/>
+														<xs:attribute name="count" type="xs:int"/>
+														<xs:attribute name="countRef" type="xs:NCName"/>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="ref" type="xs:NCName" use="required"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="count" type="xs:int"/>
+								<xs:attribute name="countRef" type="xs:NCName"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Alert">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="NotificationIntervalInSec" type="xs:int" minOccurs="0"/>
+									<xs:element ref="destination:Destination" maxOccurs="unbounded"/>
+								</xs:sequence>
+								<xs:attribute name="count" type="xs:int" use="required"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="SpikeArrest">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="ratelimitType">
+					<xs:sequence>
+						<xs:element name="Rate" type="xs:string"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="ResetQuota">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="Quota">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Identifier" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="Class" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence/>
+														<xs:attribute name="name" type="xs:NCName" use="optional"/>
+														<xs:attribute name="ref" type="xs:NCName" use="optional"/>
+														<xs:attribute name="allow" type="xs:long" use="optional"/>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="name" type="xs:NCName" use="optional"/>
+											<xs:attribute name="ref" type="xs:NCName" use="optional"/>
+											<xs:attribute name="allow" type="xs:long" use="optional"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="name" type="xs:NCName" use="optional"/>
+								<xs:attribute name="ref" type="xs:NCName" use="optional"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="ratelimitType">
+		<xs:complexContent>
+			<xs:extension base="step:stepDefinitionType">
+				<xs:sequence>
+					<xs:element name="Identifier" type="refType" minOccurs="0"/>
+					<xs:element name="MessageWeight" type="refType" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="refType">
+		<xs:sequence/>
+		<xs:attribute name="ref" type="xs:NCName" use="required"/>
+	</xs:complexType>
 </xs:schema>

--- a/schemas/policy/ratelimit.xsd
+++ b/schemas/policy/ratelimit.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../destinations.xsd"/>
+    <xs:include schemaLocation="../configuration/destinations.xsd"/>
 
     <xs:element name="Quota">
         <xs:complexType>

--- a/schemas/policy/regular_expression_protection.xsd
+++ b/schemas/policy/regular_expression_protection.xsd
@@ -5,13 +5,13 @@
   ~ trademarks are the property of their respective owners.
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
+<xs:schema targetNamespace="http://www.apigee.com/policy/regex_protection" xmlns="http://www.apigee.com/policy/regex_protection" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
 
     <xs:element name="RegularExpressionProtection">
         <xs:complexType>
             <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
+                <xs:extension base="step:stepDefinitionType">
                     <xs:sequence>
                         <xs:element name="Source" minOccurs="0" type="xs:string"/>
                         <xs:element name="IgnoreUnresolvedVariables" minOccurs="0" type="xs:boolean" default="false"/>
@@ -20,7 +20,7 @@
                             <xs:element name="QueryParam" type="namedPatternsType"/>
                             <xs:element name="Header" type="namedPatternsType"/>
                             <xs:element name="FormParam" type="namedPatternsType"/>
-                            <xs:element name="Variable" type="namedPatternsType"/>
+                            <xs:element name="variable" type="namedPatternsType"/>
                         </xs:choice>
                         <xs:element name="XMLPayload" minOccurs="0">
                             <xs:complexType>

--- a/schemas/policy/saml.xsd
+++ b/schemas/policy/saml.xsd
@@ -6,9 +6,8 @@
   ~ trademarks are the property of their respective owners.
   -->
         
-<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-    <xs:include schemaLocation="stepDefinition.xsd"/>
+<xs:schema targetNamespace="http://www.apigee.com/policy/saml"  xmlns="http://www.apigee.com/policy/saml" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
 
     <xs:element name="GenerateSAMLAssertion" type="generateSAMLAssertionBean"/>
 
@@ -38,7 +37,7 @@
 
     <xs:complexType name="abstractSAMLAssertionBean">
         <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
+            <xs:extension base="step:stepDefinitionType">
                 <xs:sequence/>
                 <xs:attribute name="ignoreContentType" type="xs:boolean" use="required"/>
             </xs:extension>
@@ -84,7 +83,7 @@
                     <xs:element name="OutputVariable" type="outputVariable" minOccurs="0"/>
                     <xs:element name="SignatureAlgorithm" type="propertyBean" minOccurs="0"/>
                     <xs:element name="Subject" type="propertyBean" minOccurs="0"/>
-                    <xs:element name="Template" type="template" minOccurs="0"/>
+                    <xs:element name="Template" type="step:template" minOccurs="0"/>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>
@@ -102,4 +101,3 @@
         </xs:complexContent>
     </xs:complexType>
 </xs:schema>
-

--- a/schemas/policy/script.xsd
+++ b/schemas/policy/script.xsd
@@ -4,21 +4,18 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="Script">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="ResourceURL" type="xs:string"/>
-                        <xs:element name="IncludeURL" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/script" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/script">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="Script">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="ResourceURL" type="xs:string"/>
+						<xs:element name="IncludeURL" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/service_callout.xsd
+++ b/schemas/policy/service_callout.xsd
@@ -4,31 +4,28 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../configuration/target_endpoint.xsd"/>
-
-    <xs:element name="ServiceCallout">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="Request" minOccurs="0">
-                            <xs:complexType>
-                                <xs:simpleContent>
-                                    <xs:extension base="xs:NCName">
-                                        <xs:attribute name="clearPayload" type="xs:boolean" default="false"/>
-                                    </xs:extension>
-                                </xs:simpleContent>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="Response" minOccurs="0" type="xs:NCName"/>
-                        <xs:element ref="HTTPTargetConnection"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/service_callout" xmlns:step="http://www.apigee.com/policy/step" xmlns:target="http://www.apigee.com/configuration/target_endpoint" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/service_callout">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:import namespace="http://www.apigee.com/configuration/target_endpoint" schemaLocation="../configuration/target_endpoint.xsd"/>
+	<xs:element name="ServiceCallout">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="Request" minOccurs="0">
+							<xs:complexType>
+								<xs:simpleContent>
+									<xs:extension base="xs:NCName">
+										<xs:attribute name="clearPayload" type="xs:boolean" default="false"/>
+									</xs:extension>
+								</xs:simpleContent>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="Response" type="xs:NCName" minOccurs="0"/>
+						<xs:element ref="target:HTTPTargetConnection"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/service_callout.xsd
+++ b/schemas/policy/service_callout.xsd
@@ -7,7 +7,7 @@
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:include schemaLocation="stepDefinition.xsd"/>
-    <xs:include schemaLocation="../target_endpoint.xsd"/>
+    <xs:include schemaLocation="../configuration/target_endpoint.xsd"/>
 
     <xs:element name="ServiceCallout">
         <xs:complexType>

--- a/schemas/policy/statistics_collector.xsd
+++ b/schemas/policy/statistics_collector.xsd
@@ -5,47 +5,37 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-        
-<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-
-
-    <xs:element name="StatisticsCollector" type="statisticsCollectionBean"/>
-
-    <xs:complexType name="statisticBean">
-        <xs:simpleContent>
-            <xs:extension base="propertyBean">
-                <xs:attribute name="name" type="xs:string" use="required"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-
-    <xs:complexType name="propertyBean">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="ref" type="xs:string"/>
-                <xs:attribute name="type" type="xs:string"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-
-    <xs:complexType name="statisticsCollectionBean">
-        <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
-                <xs:sequence>
-                    <xs:element name="Statistics" minOccurs="0">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Statistic" type="statisticBean" minOccurs="0" maxOccurs="unbounded"/>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
+<xs:schema xmlns="http://www.apigee.com/policy/stats_collector" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/stats_collector" version="1.0">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="StatisticsCollector" type="statisticsCollectionBean"/>
+	<xs:complexType name="statisticBean">
+		<xs:simpleContent>
+			<xs:extension base="propertyBean">
+				<xs:attribute name="name" type="xs:string" use="required"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="propertyBean">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="ref" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:complexType name="statisticsCollectionBean">
+		<xs:complexContent>
+			<xs:extension base="step:stepDefinitionType">
+				<xs:sequence>
+					<xs:element name="Statistics" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Statistic" type="statisticBean" minOccurs="0" maxOccurs="unbounded"/>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 </xs:schema>
-

--- a/schemas/policy/stepDefinition.xsd
+++ b/schemas/policy/stepDefinition.xsd
@@ -4,27 +4,22 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
-    <xs:complexType name="stepDefinitionType">
-        <xs:sequence/>
-        <xs:attribute name="name" type="xs:string" use="required"/>
-        <xs:attribute name="async" type="xs:boolean" use="optional" default="false"/>
-        <xs:attribute name="continueOnError" type="xs:boolean" use="optional" default="false"/>
-    </xs:complexType>
-    <xs:element name="StepDefinition" type="stepDefinitionType"/>
-
-    <xs:complexType name="messageWeightType">
-        <xs:attribute name="ref" type="xs:string" use="required"/>
-    </xs:complexType>
-
-    <xs:simpleType name="variable">
-        <xs:restriction base="xs:string"/>
-    </xs:simpleType>
-
-    <xs:simpleType name="template">
-        <xs:restriction base="xs:string"/>
-    </xs:simpleType>
-
-    <xs:element name="MessageWeight" type="messageWeightType"/>
+<xs:schema xmlns="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/step" elementFormDefault="qualified">
+	<xs:complexType name="stepDefinitionType">
+		<xs:sequence/>
+		<xs:attribute name="name" type="xs:string" use="required"/>
+		<xs:attribute name="async" type="xs:boolean" use="optional" default="false"/>
+		<xs:attribute name="continueOnError" type="xs:boolean" use="optional" default="false"/>
+	</xs:complexType>
+	<xs:complexType name="messageWeightType">
+		<xs:attribute name="ref" type="xs:string" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="variable">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:simpleType name="template">
+		<xs:restriction base="xs:string"/>
+	</xs:simpleType>
+	<xs:element name="StepDefinition" type="stepDefinitionType"/>
+	<xs:element name="MessageWeight" type="messageWeightType"/>
 </xs:schema>

--- a/schemas/policy/verify_api_key.xsd
+++ b/schemas/policy/verify_api_key.xsd
@@ -5,30 +5,24 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-        
-<xs:schema version="1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="VerifyAPIKey" type="verifyAPIKeyBean"/>
-
-    <xs:complexType name="verifyAPIKeyBean">
-        <xs:complexContent>
-            <xs:extension base="stepDefinitionType">
-                <xs:sequence>
-                    <xs:element name="APIKey" type="propertyBean" minOccurs="0"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="propertyBean">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="ref" type="xs:string"/>
-                <xs:attribute name="type" type="xs:string"/>
-            </xs:extension>
-        </xs:simpleContent>
-    </xs:complexType>
-
+<xs:schema xmlns="http://www.apigee.com/policy/verify_api_key" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/verify_api_key" version="1.0">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="VerifyAPIKey" type="verifyAPIKeyBean"/>
+	<xs:complexType name="verifyAPIKeyBean">
+		<xs:complexContent>
+			<xs:extension base="step:stepDefinitionType">
+				<xs:sequence>
+					<xs:element name="APIKey" type="propertyBean" minOccurs="0"/>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="propertyBean">
+		<xs:simpleContent>
+			<xs:extension base="xs:string">
+				<xs:attribute name="ref" type="xs:string"/>
+				<xs:attribute name="type" type="xs:string"/>
+			</xs:extension>
+		</xs:simpleContent>
+	</xs:complexType>
 </xs:schema>

--- a/schemas/policy/xml_threat_protection.xsd
+++ b/schemas/policy/xml_threat_protection.xsd
@@ -4,65 +4,59 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="XMLThreatProtection">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="Source" type="xs:NCName" minOccurs="0"/>
-                        <xs:element name="StructureLimits" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="NodeDepth" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="AttributeCountPerElement" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="NamespaceCountPerElement" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="ChildCount" minOccurs="0">
-                                        <xs:complexType>
-                                            <xs:simpleContent>
-                                                <xs:extension base="xs:int">
-                                                    <xs:attribute name="includeText" type="xs:boolean" default="true"/>
-                                                    <xs:attribute name="includeComment" type="xs:boolean"
-                                                                  default="true"/>
-                                                    <xs:attribute name="includeProcessingInstruction" type="xs:boolean"
-                                                                  default="true"/>
-                                                    <xs:attribute name="includeElement" type="xs:boolean"
-                                                                  default="true"/>
-                                                </xs:extension>
-                                            </xs:simpleContent>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="ValueLimits" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="Text" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="Attribute" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="NamespaceURI" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="Comment" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="ProcessingInstructionData" type="xs:int" default="-1" minOccurs="0"/>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="NameLimits" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="Element" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="Attribute" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="NamespacePrefix" type="xs:int" default="-1" minOccurs="0"/>
-                                    <xs:element name="ProcessingInstructionTarget" type="xs:int" default="-1" minOccurs="0"/>
-                                </xs:sequence>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/xml_threat" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/xml_threat">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="XMLThreatProtection">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="Source" type="xs:NCName" minOccurs="0"/>
+						<xs:element name="StructureLimits" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="NodeDepth" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="AttributeCountPerElement" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="NamespaceCountPerElement" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="ChildCount" minOccurs="0">
+										<xs:complexType>
+											<xs:simpleContent>
+												<xs:extension base="xs:int">
+													<xs:attribute name="includeText" type="xs:boolean" default="true"/>
+													<xs:attribute name="includeComment" type="xs:boolean" default="true"/>
+													<xs:attribute name="includeProcessingInstruction" type="xs:boolean" default="true"/>
+													<xs:attribute name="includeElement" type="xs:boolean" default="true"/>
+												</xs:extension>
+											</xs:simpleContent>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="ValueLimits" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Text" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="Attribute" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="NamespaceURI" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="Comment" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="ProcessingInstructionData" type="xs:int" default="-1" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="NameLimits" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Element" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="Attribute" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="NamespacePrefix" type="xs:int" default="-1" minOccurs="0"/>
+									<xs:element name="ProcessingInstructionTarget" type="xs:int" default="-1" minOccurs="0"/>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>

--- a/schemas/policy/xml_to_json.xsd
+++ b/schemas/policy/xml_to_json.xsd
@@ -4,62 +4,53 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="XMLToJSON">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="Source" type="xs:NCName" minOccurs="0" default="message"/>
-                        <xs:choice>
-                            <xs:element name="Options" type="xml2jsonOptionsType"/>
-                            <xs:element name="Format" type="xs:NCName"/>
-                        </xs:choice>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:element name="XMLToJSONFormats">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Format" minOccurs="0" maxOccurs="unbounded">
-                    <xs:complexType>
-                        <xs:complexContent>
-                            <xs:extension base="xml2jsonOptionsType">
-                                <xs:attribute name="name" type="xs:NCName" use="required"/>
-                            </xs:extension>
-                        </xs:complexContent>
-                    </xs:complexType>
-                </xs:element>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-
-    <xs:complexType name="xml2jsonOptionsType">
-        <xs:sequence>
-            <xs:element name="RecognizeBoolean" type="xs:boolean" default="false" minOccurs="0"/>
-            <xs:element name="RecognizeNumber" type="xs:boolean" default="false" minOccurs="0"/>
-
-            <xs:element name="RecognizeNull" type="xs:boolean" default="false" minOccurs="0"/>
-            <xs:element name="NullValue" type="xs:string" minOccurs="0"/>
-
-            <xs:element name="NamespaceBlockName" type="xs:string" minOccurs="0"/>
-            <xs:element name="DefaultNamespaceNodeName" type="xs:string" minOccurs="0"/>
-            <xs:element name="NamespaceSeparator" type="xs:string" minOccurs="0"/>
-
-            <xs:element name="TextAlwaysAsProperty" type="xs:boolean" default="false" minOccurs="0"/>
-            <xs:element name="TextNodeName" type="xs:string" minOccurs="0"/>
-
-            <xs:element name="AttributeBlockName" type="xs:string" minOccurs="0"/>
-            <xs:element name="AttributePrefix" type="xs:string" minOccurs="0"/>
-
-            <xs:element name="OutputPrefix" type="xs:string" minOccurs="0"/>
-            <xs:element name="OutputSuffix" type="xs:string" minOccurs="0"/>
-        </xs:sequence>
-    </xs:complexType>
+<xs:schema xmlns="http://www.apigee.com/policy/xml_to_json" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/xml_to_json">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="XMLToJSON">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="Source" type="xs:NCName" default="message" minOccurs="0"/>
+						<xs:choice>
+							<xs:element name="Options" type="xml2jsonOptionsType"/>
+							<xs:element name="Format" type="xs:NCName"/>
+						</xs:choice>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+	<xs:element name="XMLToJSONFormats">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Format" minOccurs="0" maxOccurs="unbounded">
+					<xs:complexType>
+						<xs:complexContent>
+							<xs:extension base="xml2jsonOptionsType">
+								<xs:attribute name="name" type="xs:NCName" use="required"/>
+							</xs:extension>
+						</xs:complexContent>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="xml2jsonOptionsType">
+		<xs:sequence>
+			<xs:element name="RecognizeBoolean" type="xs:boolean" default="false" minOccurs="0"/>
+			<xs:element name="RecognizeNumber" type="xs:boolean" default="false" minOccurs="0"/>
+			<xs:element name="RecognizeNull" type="xs:boolean" default="false" minOccurs="0"/>
+			<xs:element name="NullValue" type="xs:string" minOccurs="0"/>
+			<xs:element name="NamespaceBlockName" type="xs:string" minOccurs="0"/>
+			<xs:element name="DefaultNamespaceNodeName" type="xs:string" minOccurs="0"/>
+			<xs:element name="NamespaceSeparator" type="xs:string" minOccurs="0"/>
+			<xs:element name="TextAlwaysAsProperty" type="xs:boolean" default="false" minOccurs="0"/>
+			<xs:element name="TextNodeName" type="xs:string" minOccurs="0"/>
+			<xs:element name="AttributeBlockName" type="xs:string" minOccurs="0"/>
+			<xs:element name="AttributePrefix" type="xs:string" minOccurs="0"/>
+			<xs:element name="OutputPrefix" type="xs:string" minOccurs="0"/>
+			<xs:element name="OutputSuffix" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>

--- a/schemas/policy/xsl.xsd
+++ b/schemas/policy/xsl.xsd
@@ -4,37 +4,34 @@
   ~ registered trademarks of Apigee Corp. or its subsidiaries.  All other
   ~ trademarks are the property of their respective owners.
   -->
-
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:include schemaLocation="stepDefinition.xsd"/>
-
-    <xs:element name="XSL">
-        <xs:complexType>
-            <xs:complexContent>
-                <xs:extension base="stepDefinitionType">
-                    <xs:sequence>
-                        <xs:element name="ResourceURL" type="xs:string"/>
-                        <xs:element name="Source" type="xs:NCName" minOccurs="0" default="message"/>
-                        <xs:element name="Parameters" minOccurs="0">
-                            <xs:complexType>
-                                <xs:sequence>
-                                    <xs:element name="Parameter" minOccurs="0" maxOccurs="unbounded">
-                                        <xs:complexType>
-                                            <xs:sequence/>
-                                            <xs:attribute name="name" type="xs:NCName" use="required"/>
-                                            <xs:attribute name="ref" type="xs:NCName" use="optional"/>
-                                            <xs:attribute name="value" type="xs:string" use="optional"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:sequence>
-                                <xs:attribute name="ignoreUnresolvedVariables" type="xs:boolean" default="false"/>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="OutputVariable" type="xs:NCName" minOccurs="0"/>
-                    </xs:sequence>
-                </xs:extension>
-            </xs:complexContent>
-        </xs:complexType>
-    </xs:element>
-
+<xs:schema xmlns="http://www.apigee.com/policy/xsl" xmlns:step="http://www.apigee.com/policy/step" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.apigee.com/policy/xsl">
+	<xs:import namespace="http://www.apigee.com/policy/step" schemaLocation="stepDefinition.xsd"/>
+	<xs:element name="XSL">
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="step:stepDefinitionType">
+					<xs:sequence>
+						<xs:element name="ResourceURL" type="xs:string"/>
+						<xs:element name="Source" type="xs:NCName" default="message" minOccurs="0"/>
+						<xs:element name="Parameters" minOccurs="0">
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="Parameter" minOccurs="0" maxOccurs="unbounded">
+										<xs:complexType>
+											<xs:sequence/>
+											<xs:attribute name="name" type="xs:NCName" use="required"/>
+											<xs:attribute name="ref" type="xs:NCName" use="optional"/>
+											<xs:attribute name="value" type="xs:string" use="optional"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="ignoreUnresolvedVariables" type="xs:boolean" default="false"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="OutputVariable" type="xs:NCName" minOccurs="0"/>
+					</xs:sequence>
+				</xs:extension>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
 </xs:schema>


### PR DESCRIPTION
An alternate, more complete suggestion for updating your schemas. This not only has the correct paths, but also has valid namespaces for all the schemas (i just made them up). 

Having these can be helpful for folks who want to generate configuration documents in ways OTHER than just xml. I can run xjc against these and generate java classes and then theoretically configure my whole apigee config in java/groovy etc and then just export the final step back to xml and upload :-D.

You probably want to look at this with ?w=1 to fix the whitespace issues
