### PR TITLE
Correct code in SimpleNonBlockingExecutionReturnError.java to return …

### DIFF
--- a/doc-samples/java-cookbook/java/src/com/apigeesample/SimpleNonBlockingExecutionReturnError.java
+++ b/doc-samples/java-cookbook/java/src/com/apigeesample/SimpleNonBlockingExecutionReturnError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Apigee Corporation.  All rights reserved.
+ * Copyright (c) 2010,2016 Apigee Corporation.  All rights reserved.
  * Apigee(TM) and the Apigee logo are trademarks or
  * registered trademarks of Apigee Corp. or its subsidiaries.  All other
  * trademarks are the property of their respective owners.
@@ -30,9 +30,9 @@ import com.apigee.flow.message.MessageContext;
 @IOIntensive
 public class SimpleNonBlockingExecutionReturnError implements Execution {
 
-	@Override
-	public ExecutionResult execute(MessageContext messageContext, ExecutionContext executionContext) {
-		try {
+    @Override
+    public ExecutionResult execute(MessageContext messageContext, ExecutionContext executionContext) {
+        try {
             // message modification, IO operations, etc
             // do something here that might fail
             return ExecutionResult.SUCCESS;
@@ -40,7 +40,7 @@ public class SimpleNonBlockingExecutionReturnError implements Execution {
             ExecutionResult executionResult = new ExecutionResult(false, ExecutionResult.Action.ABORT);
             executionResult.setErrorResponse(ex.getMessage());
             executionResult.addErrorResponseHeader("ExceptionClass", ex.getClass().getName());
-            return new ExecutionResult(false, ExecutionResult.Action.ABORT);
+            return executionResult;
         }
-	}
+    }
 }


### PR DESCRIPTION
Correct code in SimpleNonBlockingExecutionReturnError.java to return the modified ExecutionResult.
The existing code has been incorrect for a long time.  

This change is not to address DOC-1628, which depends on the resolution of APIRT-3141.  This change will be useful if the fix for APIRT-3141 is to revert the changes made in 160330 w.r.t. private constructors of ExecutionResult.  In that case DOC-1628 becomes a non-issue.  