### PR TITLE
in scripts/verify_credentials.sh, fix bug in printf arguments.

### DIFF
--- a/learn-edge/scripts/verify_credentials.sh
+++ b/learn-edge/scripts/verify_credentials.sh
@@ -9,9 +9,9 @@ then
   exit
 elif [ $response -eq 403 ]
 then
-  printf Organization $org is invalid!
-  printf Please re-run the script using the right org.
+  printf "\nOrganization $org is invalid!\n"
+  printf "Please re-run the script using the right org.\n"
   exit
 else
   printf "\nCredentials verfied! Proceeding with deployment.\n\n"
-fi;
+fi


### PR DESCRIPTION
in scripts/verify_credentials.sh, fix the arguments to printf.

if the user specifies an invalid org in setenv.sh, printf could be called with the wrong arguments, causing a confusing error message.

also eliminated an unnecessary trailing semicolon after fi.
