### PR TITLE
Documentation & scripts Fixes :

### DIFF
--- a/learn-edge/README.md
+++ b/learn-edge/README.md
@@ -26,7 +26,7 @@ This is the recommended path through the examples. But you can do them in any or
 
     >Secure an API with an API key. 
 
-4.  [apikey-security-2](./apikey-security-1/README.md)
+4.  [apikey-security-2](./apikey-security-2/README.md)
 
     >Prevent an API key from being passed to the backend target service.
 

--- a/learn-edge/extract-json-payload-2/README.md
+++ b/learn-edge/extract-json-payload-2/README.md
@@ -30,7 +30,7 @@ We assume you've provisioned the Product, Developer App, and Developer as explai
 
 ### Deploy it
 
-1. `cd api-platform-samples/learn-edge/extract-json-payload`.
+1. `cd api-platform-samples/learn-edge/extract-json-payload-2`.
 2. `./deploy.sh`
 
 ### Run it

--- a/learn-edge/provisioning/setup.sh
+++ b/learn-edge/provisioning/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ## Ensure configuration variables have been set.
 source ../../setup/userconf.sh || exit 1

--- a/learn-edge/scripts/deploy_proxy.sh
+++ b/learn-edge/scripts/deploy_proxy.sh
@@ -3,7 +3,7 @@
 function deploy_proxy {
     if hash apigeetool 2>/dev/null; then
     	printf "\n\nUsing apigeetool to deploy the proxy to the $env environment in the $org org to the $url url...\n\n"
-        apigeetool deployproxy  -v -o $org -e $env --api learn-edge -L $url -d . -u $username -p $password -V
+        apigeetool deployproxy -o $org -e $env --api learn-edge -L $url -d . -u $username -p $password -V
         printf "\nIf the deployment is successful, then your API Proxy is ready to be invoked.\n"
         printf "\nRun 'invoke.sh'\n"
     else

--- a/learn-edge/service-callout-1/README.md
+++ b/learn-edge/service-callout-1/README.md
@@ -16,7 +16,7 @@ We assume you've provisioned the Product, Developer App, and Developer as explai
 
 ### Deploy it
 
-1. `cd api-platform-samples/learn-edge/extract-json-payload`.
+1. `cd api-platform-samples/learn-edge/service-callout-1`.
 2. `./deploy.sh`
 
 ### Run it

--- a/learn-edge/service-callout-2/README.md
+++ b/learn-edge/service-callout-2/README.md
@@ -18,7 +18,7 @@ We assume you've provisioned the Product, Developer App, and Developer as explai
 
 ### Deploy it
 
-1. `cd api-platform-samples/learn-edge/extract-json-payload`.
+1. `cd api-platform-samples/learn-edge/service-callout-2`.
 2. `./deploy.sh`
 
 ### Run it


### PR DESCRIPTION
* source error for ubuntu, use sh as the others scripts
* remove -v option in  apigeetool deployproxy, as deprecated option
* fixes links in documentation pointing to wrong folders