### PR TITLE
Fix oauth-advanced sample-proxy sample

### DIFF
--- a/sample-proxies/oauth-advanced/app/templates/login-app/apiproxy/resources/node/package.json
+++ b/sample-proxies/oauth-advanced/app/templates/login-app/apiproxy/resources/node/package.json
@@ -13,7 +13,7 @@
     "express-session": "^1.9.1",
     "less-middleware": "^0.1.12",
     "serve-favicon": "^2.1.6",
-    "validator": ">2.0.0"
+    "validator": "2.0.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/sample-proxies/oauth-advanced/app/templates/login-app/apiproxy/resources/node/routes/login.js
+++ b/sample-proxies/oauth-advanced/app/templates/login-app/apiproxy/resources/node/routes/login.js
@@ -60,12 +60,14 @@ console.log("authUrl: " + authUrl);
 	var errors = validateLoginForm(username, password);
 	if (typeof errors !== 'undefined' && errors.length > 0) {
 		console.log(errors);
+		var basePath = utils.getBasePath(req);
 		res.render ('login',
 			{
 				result: 'validation_failed',
 				errors: errors,
 				username: username,
-				password: password
+				password: password,
+				basePath: basePath
 			});
 		return;
 	}

--- a/sample-proxies/oauth-advanced/app/templates/login-app/apiproxy/resources/node/routes/registration.js
+++ b/sample-proxies/oauth-advanced/app/templates/login-app/apiproxy/resources/node/routes/registration.js
@@ -24,6 +24,7 @@ exports.post = function(req, res){
 	var errors = validateForm(title, firstname, lastname, email, password, verifypassword);
 	if (typeof errors !== 'undefined' && errors.length > 0) {
 		console.log(errors);
+		var basePath = utils.getBasePath(req);
 		res.render ('registration',
 			{
 				result: 'validation_failed',
@@ -31,7 +32,8 @@ exports.post = function(req, res){
 				title: title,
 				firstname: firstname,
 				lastname: lastname,
-				email: email
+				email: email,
+				basePath: basePath
 			});
 		return;
 	}
@@ -46,7 +48,7 @@ exports.post = function(req, res){
 
 	// Set the user authentication endpoint information here
 	//var authUrl = 'witman-prod.apigee.net';
-        var authUrl = config.envInfo.org + "-" + config.envInfo.env + "." + config.envInfo.domain;
+	var authUrl = config.envInfo.org + "-" + config.envInfo.env + "." + config.envInfo.domain;
 	var authPath = '/v1/users';
 	var authPort = 443;
 	var authMethod = 'POST';
@@ -101,10 +103,11 @@ exports.post = function(req, res){
 	  	  			var message = 'Unknown failure.';
 	  	  		}
 
+				var basePath = utils.getBasePath(req);
 	  	  		res.render('registration', {
 	  	  			result: 'reg_failed',
-	  	  			message: message
-
+	  	  			message: message,
+					basePath: basePath
 	  	  		});
 	  	  	}
 	  	});


### PR DESCRIPTION
This PR is a quick fix for the oauth-advanced sample-proxy sample.

There are two changes:

1. Fix the validator package version to 2.0.0 because new versions are not backwards compatible. A better solution could be update the logic to the newest validator version.

2. Add the basePath variable to ejs render calls on login and registration when an error or validation issue occurs.

Regards!