### PR TITLE
use printf instead of echo for more shell consistency

### DIFF
--- a/sample-proxies/oauth-client-credentials/invoke.sh
+++ b/sample-proxies/oauth-client-credentials/invoke.sh
@@ -40,7 +40,7 @@ printf "\nRetrieved secret: $secret\n"
 
 printf "\n\nBase64 encrypt the key:secret values for the Basic Auth header: "
 
-auth=`echo -n $key:$secret | base64`
+auth=$(printf $key:$secret | base64)
 
 printf "\nBasic: $auth"
 


### PR DESCRIPTION
echo -n works differently depending on the shell. Using printf is more consistent.