### PR TITLE
feature: payload to Query String

### DIFF
--- a/sample-sharedflows/SF-PayloadToQueryString/README.md
+++ b/sample-sharedflows/SF-PayloadToQueryString/README.md
@@ -15,6 +15,8 @@ create flow callout policy in your proxy
 </FlowCallout>
 ```
 
+---
+
 ## Call the proxy
 
 ```sh

--- a/sample-sharedflows/SF-PayloadToQueryString/README.md
+++ b/sample-sharedflows/SF-PayloadToQueryString/README.md
@@ -1,0 +1,30 @@
+## USAGE
+
+create flow callout policy in your proxy
+
+```xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<FlowCallout async="false" continueOnError="false" enabled="true" name="FC-PayloadToQueryString">
+    <DisplayName>FC-PayloadToQueryString</DisplayName>
+    <FaultRules/>
+    <Properties/>
+    <Parameters>
+        <Parameter name="SF-PayloadToQueryStrin.fields">["name"]</Parameter>
+    </Parameters>
+    <SharedFlowBundle>SF-PayloadToQueryString</SharedFlowBundle>
+</FlowCallout>
+```
+
+## Call the proxy
+
+```sh
+curl --location --request POST {{proxyURL}} \
+--header 'Content-Type: application/json' \
+--data-raw '{
+    "name": "lama",
+    "gender": "female",
+    "age": 26
+}'
+```
+
+

--- a/sample-sharedflows/SF-PayloadToQueryString/README.md
+++ b/sample-sharedflows/SF-PayloadToQueryString/README.md
@@ -1,6 +1,6 @@
 ## USAGE
 
-create flow callout policy in your proxy
+**create flow callout policy in your proxy**
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>

--- a/sample-sharedflows/SF-PayloadToQueryString/sharedflowbundle/policies/JS-ExtractPayloadAndAssignQueryString.xml
+++ b/sample-sharedflows/SF-PayloadToQueryString/sharedflowbundle/policies/JS-ExtractPayloadAndAssignQueryString.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Javascript async="false" continueOnError="false" enabled="true" timeLimit="200" name="JS-ExtractPayloadAndAssignQueryString">
+    <DisplayName>JS-ExtractPayloadAndAssignQueryString</DisplayName>
+    <Properties/>
+    <ResourceURL>jsc://JS-ExtractPayloadAndAssignQueryString.js</ResourceURL>
+</Javascript>

--- a/sample-sharedflows/SF-PayloadToQueryString/sharedflowbundle/resources/jsc/JS-ExtractPayloadAndAssignQueryString.js
+++ b/sample-sharedflows/SF-PayloadToQueryString/sharedflowbundle/resources/jsc/JS-ExtractPayloadAndAssignQueryString.js
@@ -1,0 +1,24 @@
+if(request.content !== null || request.content !== ''){
+    try{
+        var fields = JSON.parse(context.getVariable("SF-PayloadToQueryStrin.fields"));
+        payload = JSON.parse(request.content);
+        
+        for(var i in fields){
+            var field = fields[i];
+            if(payload[field] !== undefined){
+                print("[INFO] found key: " + field);
+                context.setVariable("request.queryparam."+field, payload[field]);
+                delete payload[field];
+            }
+            else{
+                print("[WARN] didn't find key: " + field);
+            }
+        }
+    }catch(e){
+        print("[ERROR] Exception Occured:\t" + e);
+    }
+    finally{
+        print("[INFO] Assigning the new payload to the request object");
+        context.setVariable("request.content", JSON.stringify(payload));
+    }
+}

--- a/sample-sharedflows/SF-PayloadToQueryString/sharedflowbundle/sharedflows/default.xml
+++ b/sample-sharedflows/SF-PayloadToQueryString/sharedflowbundle/sharedflows/default.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<SharedFlow name="default">
+    <Step>
+        <Name>JS-ExtractPayloadAndAssignQueryString</Name>
+    </Step>
+</SharedFlow>


### PR DESCRIPTION
added a sharedflow to move fields from client's json payload to target's query string since the request body gets encrypted in the https packet unlike the url